### PR TITLE
Fix Hugging Face image generation failures on Cloud Run 

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -108,6 +108,7 @@ jobs:
               SUPABASE_SERVICE_KEY=SUPABASE_SERVICE_KEY:latest,\
               SERPAPI_KEY=SERPAPI_KEY:latest,\
               HF_API_TOKEN=HF_API_TOKEN:latest,\
+              HUGGINGFACE_HUB_TOKEN=HF_API_TOKEN:latest,\
               ALLOWED_ORIGINS=ALLOWED_ORIGINS:latest,\
               GA4_PROPERTY_ID=GA4_PROPERTY_ID:latest" \
             --set-env-vars "\

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -53,7 +53,8 @@ jobs:
           # All web deployments (production and preview channels) use this same
           # URI so Google only needs one entry in its Authorized redirect URIs list.
           EXPO_PUBLIC_OAUTH_REDIRECT_URI: "https://${{ secrets.FIREBASE_PROJECT_ID }}.web.app"
-        run: npx expo export --platform web
+        # export:web = expo export to dist/ + copy static privacy/terms HTML for Firebase Hosting
+        run: npm run export:web
 
       # ── 5. Deploy to Firebase Hosting ────────────────────────────────────────
       # Uses the official Firebase action which reads firebase.json from the

--- a/.github/workflows/preview-backend.yml
+++ b/.github/workflows/preview-backend.yml
@@ -109,6 +109,7 @@ jobs:
               SUPABASE_SERVICE_KEY=SUPABASE_SERVICE_KEY:latest,\
               SERPAPI_KEY=SERPAPI_KEY:latest,\
               HF_API_TOKEN=HF_API_TOKEN:latest,\
+              HUGGINGFACE_HUB_TOKEN=HF_API_TOKEN:latest,\
               GA4_PROPERTY_ID=GA4_PROPERTY_ID:latest" \
             --set-env-vars "\
               CORS_ORIGIN_REGEX=https://.*\.web\.app,\

--- a/.github/workflows/preview-frontend.yml
+++ b/.github/workflows/preview-frontend.yml
@@ -66,7 +66,7 @@ jobs:
           # the stable production URL instead. That page calls maybeCompleteAuthSession()
           # which posts the token back to this window via postMessage before closing.
           EXPO_PUBLIC_OAUTH_REDIRECT_URI: "https://${{ secrets.FIREBASE_PROJECT_ID }}.web.app"
-        run: npx expo export --platform web
+        run: npm run export:web
 
       # ── 5. Strip Cloud Run rewrites for preview deploy ────────────────────────
       # Firebase Hosting validates every rewrite rule at deploy time by calling

--- a/firebase.json
+++ b/firebase.json
@@ -36,6 +36,14 @@
     ],
     "rewrites": [
       {
+        "source": "/privacy",
+        "destination": "/privacy.html"
+      },
+      {
+        "source": "/terms",
+        "destination": "/terms.html"
+      },
+      {
         "source": "/wardrobe/**",
         "run": {
           "serviceId": "misfitai-backend",

--- a/misfitai-mobile/App.tsx
+++ b/misfitai-mobile/App.tsx
@@ -9,6 +9,7 @@ import { WeeklyPlanScreen } from './src/WeeklyPlanScreen';
 import { registerSignupWithBackend, USE_MOCK_API } from './src/api';
 import { AtmosphereBackground } from './src/AtmosphereBackground';
 import { AuthScreen, type AuthMode, type AuthProvider, type UserProfile } from './src/AuthScreen';
+import { ProfileSetupScreen } from './src/ProfileSetupScreen';
 import { palette, radius, type } from './src/theme';
 import { initAnalytics, trackAuthSuccess } from './src/analytics';
 
@@ -22,6 +23,8 @@ type Session = {
   profile?: UserProfile;
   /** Stable user id derived at auth-time, used for all API calls. */
   userId: string;
+  /** If true, optional profile questions were completed (or intentionally skipped). */
+  profileCompleted?: boolean;
 };
 
 /** Stable user id for API/Supabase: provider id, or normalized email, or fallback. */
@@ -154,7 +157,13 @@ export default function App() {
   const handleAuthenticated = useCallback(
     (provider: AuthProvider, mode: AuthMode, profile?: UserProfile, accessToken?: string) => {
       const userId = deriveUserIdFromProfile(profile);
-      const next: Session = { provider, mode, profile, userId };
+      const next: Session = {
+        provider,
+        mode,
+        profile,
+        userId,
+        profileCompleted: mode === 'signup' ? false : true,
+      };
       setSession(next);
       trackAuthSuccess(provider);
       AsyncStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(next));
@@ -179,6 +188,23 @@ export default function App() {
 
   if (!session) {
     return <AuthScreen onAuthenticated={handleAuthenticated} />;
+  }
+
+  if (session.mode === 'signup' && session.profileCompleted !== true) {
+    return (
+      <ProfileSetupScreen
+        initialProfile={session.profile}
+        onDone={(profilePatch) => {
+          const next: Session = {
+            ...session,
+            profile: { ...(session.profile ?? {}), ...profilePatch },
+            profileCompleted: true,
+          };
+          setSession(next);
+          AsyncStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(next));
+        }}
+      />
+    );
   }
 
   return (

--- a/misfitai-mobile/package.json
+++ b/misfitai-mobile/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "export:web": "expo export --platform web --output-dir dist && node ./scripts/copy-static-pages.mjs"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^3.0.1",

--- a/misfitai-mobile/scripts/copy-static-pages.mjs
+++ b/misfitai-mobile/scripts/copy-static-pages.mjs
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(process.cwd());
+const srcDir = path.join(root, 'static-pages');
+const outDir = path.join(root, 'dist');
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function copyFile(from, to) {
+  fs.copyFileSync(from, to);
+  // eslint-disable-next-line no-console
+  console.log(`Copied ${path.relative(root, from)} -> ${path.relative(root, to)}`);
+}
+
+ensureDir(outDir);
+
+const files = [
+  { from: path.join(srcDir, 'privacy.html'), to: path.join(outDir, 'privacy.html') },
+  { from: path.join(srcDir, 'terms.html'), to: path.join(outDir, 'terms.html') },
+];
+
+for (const f of files) {
+  if (!fs.existsSync(f.from)) {
+    throw new Error(`Missing static page: ${f.from}`);
+  }
+  copyFile(f.from, f.to);
+}
+

--- a/misfitai-mobile/src/AuthScreen.tsx
+++ b/misfitai-mobile/src/AuthScreen.tsx
@@ -31,17 +31,15 @@ export type UserProfile = {
   photoUrl?: string | null;
   /** Google/Apple may not provide; user can set in app later. */
   gender?: 'male' | 'female' | 'other' | null;
-  /** Birthday from Google People API (YYYY-MM-DD) if available and shared. */
+  /** Birthday captured in-app (YYYY-MM-DD) if provided. */
   birthday?: string | null;
 };
 
-/** Scopes we request from Google: name, email, photo, gender, birthday, and calendar read. */
+/** Scopes we request from Google: OpenID identity + calendar read-only. */
 const GOOGLE_SCOPES = [
   'openid',
   'https://www.googleapis.com/auth/userinfo.profile',
   'https://www.googleapis.com/auth/userinfo.email',
-  'https://www.googleapis.com/auth/user.gender.read',
-  'https://www.googleapis.com/auth/user.birthday.read',
   'https://www.googleapis.com/auth/calendar.readonly',
 ];
 
@@ -92,41 +90,25 @@ export function AuthScreen({
   }, [entrance]);
 
   const fetchGoogleProfile = useCallback(async (accessToken: string): Promise<UserProfile> => {
-    const personFields = 'genders,birthdays,names,emailAddresses,photos';
-    const res = await fetch(
-      `https://people.googleapis.com/v1/people/me?personFields=${personFields}`,
-      { headers: { Authorization: `Bearer ${accessToken}` } }
-    );
+    // Use the standard userinfo endpoint (non-sensitive). Avoid Google People API
+    // so we don't request sensitive scopes (birthday/gender).
+    const res = await fetch(`https://www.googleapis.com/oauth2/v3/userinfo`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
     if (!res.ok) return {};
     const data = (await res.json()) as {
-      resourceName?: string;
-      genders?: Array<{ value?: string }>;
-      birthdays?: Array<{ date?: { year?: number; month?: number; day?: number } }>;
-      names?: Array<{ displayName?: string }>;
-      emailAddresses?: Array<{ value?: string }>;
-      photos?: Array<{ url?: string }>;
+      sub?: string;
+      email?: string;
+      name?: string;
+      picture?: string;
     };
-    const resourceName = data.resourceName;
-    const id = resourceName
-      ? `google-${resourceName.replace(/^people\//, '')}`
-      : null;
-    const genderRaw = data.genders?.[0]?.value;
-    const gender =
-      genderRaw === 'male' || genderRaw === 'female' || genderRaw === 'other'
-        ? genderRaw
-        : null;
-    const b = data.birthdays?.[0]?.date;
-    const birthday =
-      b && b.year != null && b.month != null && b.day != null
-        ? `${b.year}-${String(b.month).padStart(2, '0')}-${String(b.day).padStart(2, '0')}`
-        : null;
     return {
-      id,
-      email: data.emailAddresses?.[0]?.value ?? null,
-      displayName: data.names?.[0]?.displayName ?? null,
-      photoUrl: data.photos?.[0]?.url ?? null,
-      gender,
-      birthday,
+      id: data.sub ? `google-${data.sub}` : null,
+      email: data.email ?? null,
+      displayName: data.name ?? null,
+      photoUrl: data.picture ?? null,
+      gender: null,
+      birthday: null,
     };
   }, []);
 

--- a/misfitai-mobile/src/ProfileSetupScreen.tsx
+++ b/misfitai-mobile/src/ProfileSetupScreen.tsx
@@ -1,0 +1,231 @@
+import React, { useMemo, useState } from 'react';
+import { Platform, Pressable, SafeAreaView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { AtmosphereBackground } from './AtmosphereBackground';
+import { palette, radius, type } from './theme';
+import type { UserProfile } from './AuthScreen';
+
+function isValidBirthday(value: string): boolean {
+  const v = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) return false;
+  const [y, m, d] = v.split('-').map((x) => Number(x));
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return false;
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > 31) return false;
+  // Basic calendar sanity (avoid timezone quirks by using UTC)
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+
+export function ProfileSetupScreen({
+  initialProfile,
+  onDone,
+}: {
+  initialProfile?: UserProfile;
+  onDone: (profilePatch: Pick<UserProfile, 'gender' | 'birthday'>) => void;
+}) {
+  const [gender, setGender] = useState<UserProfile['gender']>(initialProfile?.gender ?? null);
+  const [birthday, setBirthday] = useState<string>(initialProfile?.birthday ?? '');
+  const [birthdayTouched, setBirthdayTouched] = useState(false);
+
+  const birthdayError = useMemo(() => {
+    const value = birthday.trim();
+    if (!birthdayTouched) return null;
+    if (!value) return null; // optional
+    return isValidBirthday(value) ? null : 'Use YYYY-MM-DD (e.g., 2001-04-07).';
+  }, [birthday, birthdayTouched]);
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <AtmosphereBackground />
+      <View style={styles.container}>
+        <Text style={styles.brand}>misfitAI</Text>
+        <Text style={styles.title}>A quick question</Text>
+        <Text style={styles.subtitle}>
+          We no longer pull birthday or gender from Google. Add them here (optional) so we can personalize your
+          experience.
+        </Text>
+
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Gender</Text>
+          <View style={styles.row}>
+            {([
+              { key: 'female', label: 'Female' },
+              { key: 'male', label: 'Male' },
+              { key: 'other', label: 'Other' },
+            ] as const).map((g) => {
+              const active = gender === g.key;
+              return (
+                <Pressable
+                  key={g.key}
+                  onPress={() => setGender(active ? null : g.key)}
+                  style={[styles.chip, active && styles.chipActive]}
+                >
+                  <Text style={[styles.chipText, active && styles.chipTextActive]}>{g.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={[styles.sectionTitle, { marginTop: 16 }]}>Birthday</Text>
+          <TextInput
+            value={birthday}
+            onChangeText={setBirthday}
+            placeholder="YYYY-MM-DD (optional)"
+            placeholderTextColor={palette.muted}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType={Platform.OS === 'web' ? 'default' : 'numbers-and-punctuation'}
+            style={[styles.input, birthdayError && styles.inputError]}
+            onBlur={() => setBirthdayTouched(true)}
+          />
+          {birthdayError ? <Text style={styles.errorText}>{birthdayError}</Text> : null}
+
+          <View style={styles.actions}>
+            <Pressable
+              onPress={() => onDone({ gender: null, birthday: null })}
+              style={[styles.button, styles.buttonGhost]}
+            >
+              <Text style={[styles.buttonText, styles.buttonGhostText]}>Skip</Text>
+            </Pressable>
+            <Pressable
+              onPress={() =>
+                onDone({
+                  gender: gender ?? null,
+                  birthday: birthday.trim() ? birthday.trim() : null,
+                })
+              }
+              style={[styles.button, styles.buttonPrimary]}
+              disabled={Boolean(birthdayError)}
+            >
+              <Text style={[styles.buttonText, styles.buttonPrimaryText]}>Continue</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: palette.bg,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 18,
+    paddingTop: 48,
+  },
+  brand: {
+    fontSize: 18,
+    color: palette.ink,
+    fontFamily: type.display,
+    marginBottom: 10,
+  },
+  title: {
+    fontSize: 26,
+    color: palette.ink,
+    fontFamily: type.title,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: palette.muted,
+    fontFamily: type.body,
+    lineHeight: 20,
+    marginBottom: 18,
+  },
+  card: {
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panel,
+    padding: 16,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    color: palette.muted,
+    fontFamily: type.bodyDemi,
+    marginBottom: 10,
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  chip: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  chipActive: {
+    backgroundColor: palette.accent,
+    borderColor: palette.accent,
+  },
+  chipText: {
+    fontSize: 13,
+    color: palette.inkSoft,
+    fontFamily: type.bodyMedium,
+  },
+  chipTextActive: {
+    color: palette.panelStrong,
+  },
+  input: {
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: palette.ink,
+    fontFamily: type.body,
+  },
+  inputError: {
+    borderColor: palette.error,
+  },
+  errorText: {
+    marginTop: 8,
+    color: palette.error,
+    fontSize: 12,
+    fontFamily: type.body,
+  },
+  actions: {
+    marginTop: 18,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 10,
+  },
+  button: {
+    flex: 1,
+    borderRadius: radius.md,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  buttonGhost: {
+    backgroundColor: 'transparent',
+    borderColor: palette.lineStrong,
+  },
+  buttonPrimary: {
+    backgroundColor: palette.accent,
+    borderColor: palette.accent,
+  },
+  buttonText: {
+    fontSize: 14,
+    fontFamily: type.bodyDemi,
+  },
+  buttonGhostText: {
+    color: palette.inkSoft,
+  },
+  buttonPrimaryText: {
+    color: palette.panelStrong,
+  },
+});
+

--- a/misfitai-mobile/static-pages/privacy.html
+++ b/misfitai-mobile/static-pages/privacy.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MisfitAI Privacy Policy</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f2f2f0;
+        --panel: #fafaf8;
+        --ink: #111111;
+        --muted: #6f706b;
+        --line: #d9d9d4;
+        --max: 860px;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+      }
+      main {
+        max-width: var(--max);
+        margin: 0 auto;
+        padding: 40px 20px 64px;
+      }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        padding: 24px;
+      }
+      h1 {
+        font-size: 28px;
+        margin: 0 0 8px;
+      }
+      .meta {
+        color: var(--muted);
+        margin: 0 0 24px;
+      }
+      h2 {
+        font-size: 16px;
+        margin: 24px 0 8px;
+      }
+      p,
+      li {
+        line-height: 1.55;
+      }
+      a {
+        color: inherit;
+      }
+      code {
+        background: rgba(0, 0, 0, 0.05);
+        padding: 0 6px;
+        border-radius: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="card">
+        <h1>Privacy Policy</h1>
+        <p class="meta">Last updated: 2026-04-07</p>
+
+        <p>
+          MisfitAI (“we”, “us”) is an AI wardrobe planner. This Privacy Policy explains what information we collect,
+          how we use it, and the choices you have.
+        </p>
+
+        <h2>Information we collect</h2>
+        <ul>
+          <li><strong>Account info</strong>: basic profile details you provide (e.g., name, email).</li>
+          <li><strong>Optional profile info</strong>: birthday and gender if you choose to enter them in-app.</li>
+          <li><strong>Calendar access</strong>: if you connect Google Calendar, we request read-only access to fetch event
+            titles/times needed to generate outfit plans.</li>
+          <li><strong>Wardrobe content</strong>: images and metadata you upload to build your wardrobe.</li>
+          <li><strong>Usage analytics</strong>: limited event data to help us improve the product.</li>
+        </ul>
+
+        <h2>How we use information</h2>
+        <ul>
+          <li>Provide the core service (wardrobe management and weekly outfit recommendations).</li>
+          <li>Personalize recommendations (optional fields only).</li>
+          <li>Maintain security and prevent abuse.</li>
+          <li>Measure and improve performance and usability.</li>
+        </ul>
+
+        <h2>Google user data</h2>
+        <p>
+          If you connect Google Calendar, we use the <code>calendar.readonly</code> scope to read calendar events you can
+          access. We do not request access to your birthday or gender from Google.
+        </p>
+
+        <h2>Sharing</h2>
+        <p>We do not sell your personal information. We may share data with service providers that help us run the app.</p>
+
+        <h2>Data retention</h2>
+        <p>We retain data for as long as needed to provide the service and comply with legal obligations.</p>
+
+        <h2>Your choices</h2>
+        <ul>
+          <li>You can choose not to provide optional profile fields.</li>
+          <li>You can disconnect Google access from your Google Account at any time.</li>
+        </ul>
+
+        <h2>Contact</h2>
+        <p>
+          Questions? Email us at <a href="mailto:misfitai2000@gmail.com">misfitai2000@gmail.com</a>.
+        </p>
+      </div>
+    </main>
+  </body>
+</html>
+

--- a/misfitai-mobile/static-pages/terms.html
+++ b/misfitai-mobile/static-pages/terms.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MisfitAI Terms of Service</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f2f2f0;
+        --panel: #fafaf8;
+        --ink: #111111;
+        --muted: #6f706b;
+        --line: #d9d9d4;
+        --max: 860px;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+      }
+      main {
+        max-width: var(--max);
+        margin: 0 auto;
+        padding: 40px 20px 64px;
+      }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        padding: 24px;
+      }
+      h1 {
+        font-size: 28px;
+        margin: 0 0 8px;
+      }
+      .meta {
+        color: var(--muted);
+        margin: 0 0 24px;
+      }
+      h2 {
+        font-size: 16px;
+        margin: 24px 0 8px;
+      }
+      p,
+      li {
+        line-height: 1.55;
+      }
+      a {
+        color: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="card">
+        <h1>Terms of Service</h1>
+        <p class="meta">Last updated: 2026-04-07</p>
+
+        <p>
+          By using MisfitAI (“the Service”), you agree to these Terms. If you do not agree, do not use the Service.
+        </p>
+
+        <h2>Use of the Service</h2>
+        <ul>
+          <li>You are responsible for the content you upload and the actions taken using your account.</li>
+          <li>You agree not to misuse the Service or attempt to disrupt or access it in unauthorized ways.</li>
+        </ul>
+
+        <h2>Calendar connections</h2>
+        <p>
+          If you connect Google Calendar, you authorize MisfitAI to read calendar events using read-only access in order
+          to generate outfit plans. You can revoke access at any time from your Google Account settings.
+        </p>
+
+        <h2>AI outputs</h2>
+        <p>
+          Recommendations are suggestions only. You remain responsible for your decisions and how you use the output.
+        </p>
+
+        <h2>Availability</h2>
+        <p>
+          We may change, suspend, or discontinue the Service at any time. The Service is provided “as is” without
+          warranties.
+        </p>
+
+        <h2>Limitation of liability</h2>
+        <p>
+          To the maximum extent permitted by law, MisfitAI is not liable for indirect, incidental, special, or
+          consequential damages arising out of your use of the Service.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions? Email <a href="mailto:misfitai2000@gmail.com">misfitai2000@gmail.com</a>.
+        </p>
+      </div>
+    </main>
+  </body>
+</html>
+

--- a/vision/image_gen.py
+++ b/vision/image_gen.py
@@ -5,6 +5,7 @@ import logging
 import os
 from functools import lru_cache
 
+import httpx
 from huggingface_hub import InferenceClient
 from PIL import Image
 
@@ -33,6 +34,9 @@ def _hf_inference_client() -> InferenceClient:
             "Set HF_API_TOKEN (or HUGGINGFACE_HUB_TOKEN) in the backend env. "
             "Create a token at https://huggingface.co/settings/tokens"
         )
+    # Hub metadata calls (e.g. GET /api/models/...) use HUGGINGFACE_HUB_TOKEN from the
+    # environment; without it, Cloud Run's shared egress IP is rate-limited as anonymous.
+    os.environ.setdefault("HUGGINGFACE_HUB_TOKEN", token)
     # Use Inference Providers routing so we don't hardcode router URLs.
     return InferenceClient(provider="hf-inference", api_key=token)
 
@@ -76,7 +80,19 @@ def _generate_with_hf_flux(prompt: str, size: int) -> bytes:
         )
     except Exception as exc:
         logger.exception("ImageGen(HF) request failed")
-        raise RuntimeError("Image generation failed (Hugging Face). Check HF_API_TOKEN/quota and retry.") from exc
+        detail = "Image generation failed (Hugging Face). Check HF_API_TOKEN/quota and retry."
+        err = exc
+        while err is not None:
+            if isinstance(err, httpx.HTTPStatusError) and err.response.status_code == 429:
+                detail = (
+                    "Hugging Face returned HTTP 429 (rate limit). "
+                    "Cloud Run uses shared egress IPs that HF often throttles; "
+                    "ensure HF_API_TOKEN is set (and redeploy so HUGGINGFACE_HUB_TOKEN is populated for Hub API calls). "
+                    "If it persists, wait and retry, reduce garments per image, or use HF billing / higher limits."
+                )
+                break
+            err = err.__cause__
+        raise RuntimeError(detail) from exc
 
     raw = io.BytesIO()
     image.save(raw, format="PNG")


### PR DESCRIPTION
## Summary

Fixes Hugging Face image generation failures on Cloud Run caused by **HTTP 429** on Hub metadata requests (`GET /api/models/black-forest-labs/FLUX.1-schnell`). Those calls authenticate via **`HUGGINGFACE_HUB_TOKEN`** in the environment; we previously only exposed **`HF_API_TOKEN`** to `InferenceClient`, so some traffic looked anonymous and hit **shared Cloud Run egress IP** rate limits.

## Changes

### `vision/image_gen.py`

- After resolving the token from `HF_API_TOKEN` or `HUGGINGFACE_HUB_TOKEN`, set  
  `os.environ.setdefault("HUGGINGFACE_HUB_TOKEN", token)`  
  so `huggingface_hub` Hub API calls use the same credential.
- On **`httpx.HTTPStatusError` with status 429**, raise a clearer `RuntimeError` explaining shared-IP throttling and next steps (redeploy with hub token, retry, fewer garments per image, HF limits/billing).

### CI / Cloud Run deploy

- **`.github/workflows/deploy-backend.yml`** and **`preview-backend.yml`**: add  
  `HUGGINGFACE_HUB_TOKEN=HF_API_TOKEN:latest`  
  under `--set-secrets` so Cloud Run injects the hub token from the existing Secret Manager secret (same value as `HF_API_TOKEN`).

## How to verify

- Deploy backend; in Cloud Run → service → **Variables & secrets**, confirm **`HUGGINGFACE_HUB_TOKEN`** is present (secret-sourced).
- Run vision flow that triggers FLUX image gen; logs should no longer show 429 on `/api/models/...` for anonymous-style traffic when the token is valid.
- If 429 persists, it may still be **account/quota or IP-level** limits on HF’s side; wait, retry, or upgrade HF usage as needed.

## Notes

- No new Secret Manager secret name is required: both env vars reference **`HF_API_TOKEN:latest`**.
- Local dev: set **`HF_API_TOKEN`** and/or **`HUGGINGFACE_HUB_TOKEN`** in repo root `.env` (see `.env.example`).