### PR TITLE
Add Manual Login

### DIFF
--- a/backend/analytics_metrics.py
+++ b/backend/analytics_metrics.py
@@ -10,7 +10,8 @@ Aggregate product metrics for an internal dashboard.
   Formspree Submissions API (paid plans); else CSV URL; else Supabase ``waitlist`` table.
 - **page_views** / **active_users**: Google Analytics 4, when ``GA4_PROPERTY_ID``
   and Application Default Credentials (or ``GOOGLE_APPLICATION_CREDENTIALS``)
-  are configured.
+  are configured. GA4 ``activeUsers`` can exceed **signups** because it counts
+  all property traffic (including anonymous), not only registered app users.
 
 Until GA4 or Supabase credentials are wired for production, numeric fields fall
 back to ``0`` so callers always receive a stable JSON shape.

--- a/backend/db.py
+++ b/backend/db.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from datetime import datetime
 from functools import lru_cache
-from typing import Any, List, Optional
+from typing import Any, List, Optional, TypedDict
 
+import bcrypt
 from supabase import Client, create_client
 
 from .models import (
@@ -24,6 +26,17 @@ _local_wardrobes: dict[str, List[GarmentItem]] = {}
 _local_measurements: dict[str, BodyMeasurements] = {}
 # OAuth logins (no Supabase Auth): POST /analytics/register fills this in local dev.
 _local_signup_user_ids: set[str] = set()
+# Email/password users when Supabase is unavailable or table writes fall back (see create_password_user).
+_local_app_users_by_email: dict[str, dict[str, str]] = {}
+
+
+class PasswordUserRow(TypedDict):
+    user_id: str
+    email: str
+    password_hash: str
+
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
 @lru_cache(maxsize=1)
@@ -54,6 +67,116 @@ def _measurements_table_name() -> str:
 
 def _signup_registry_table() -> str:
     return (os.getenv("SUPABASE_SIGNUPS_TABLE") or "analytics_registered_users").strip() or "analytics_registered_users"
+
+
+def _app_users_table() -> str:
+    return (os.getenv("SUPABASE_APP_USERS_TABLE") or "app_users").strip() or "app_users"
+
+
+def normalize_login_email(email: str) -> str:
+    """Lowercase trimmed email for lookups (must match mobile ``deriveUserIdFromProfile`` input)."""
+    return (email or "").strip().lower()
+
+
+def user_id_from_email(email_normalized: str) -> str:
+    """Same stable id the Expo app uses when profile.email is set without OAuth ``sub``."""
+    return "email-" + email_normalized.replace("@", "-at-").replace(".", "-dot-")
+
+
+def is_valid_login_email(email: str) -> bool:
+    normalized = normalize_login_email(email)
+    if not normalized or len(normalized) > 254:
+        return False
+    return bool(_EMAIL_RE.match(normalized))
+
+
+def get_password_user_by_email(email_normalized: str) -> Optional[PasswordUserRow]:
+    if _use_local_store():
+        row = _local_app_users_by_email.get(email_normalized)
+        if not row:
+            return None
+        return {
+            "user_id": row["user_id"],
+            "email": row["email"],
+            "password_hash": row["password_hash"],
+        }
+    try:
+        result = (
+            get_supabase_client()
+            .table(_app_users_table())
+            .select("user_id,email,password_hash")
+            .eq("email", email_normalized)
+            .maybe_single()
+            .execute()
+        )
+        data = result.data
+        if not isinstance(data, dict):
+            return None
+        uid = data.get("user_id")
+        em = data.get("email")
+        ph = data.get("password_hash")
+        if not uid or not em or not ph:
+            return None
+        return {"user_id": str(uid), "email": str(em), "password_hash": str(ph)}
+    except Exception:
+        logger.exception("get_password_user_by_email failed email=%r", email_normalized[:80])
+        return None
+
+
+def create_password_user(email_normalized: str, password_plain: str) -> PasswordUserRow:
+    """
+    Create a new email/password row. Raises ``ValueError("email_taken")`` if the email exists.
+    """
+    if not is_valid_login_email(email_normalized):
+        raise ValueError("invalid_email")
+    if len(password_plain) < 8:
+        raise ValueError("weak_password")
+
+    if get_password_user_by_email(email_normalized):
+        raise ValueError("email_taken")
+
+    pw_hash = bcrypt.hashpw(password_plain.encode("utf-8"), bcrypt.gensalt()).decode("ascii")
+    user_id = user_id_from_email(email_normalized)
+    row: PasswordUserRow = {"user_id": user_id, "email": email_normalized, "password_hash": pw_hash}
+
+    if _use_local_store():
+        _local_app_users_by_email[email_normalized] = {
+            "user_id": user_id,
+            "email": email_normalized,
+            "password_hash": pw_hash,
+        }
+        return row
+
+    try:
+        get_supabase_client().table(_app_users_table()).insert(
+            {
+                "user_id": user_id,
+                "email": email_normalized,
+                "password_hash": pw_hash,
+            }
+        ).execute()
+        return row
+    except Exception:
+        logger.exception("create_password_user insert failed email=%r", email_normalized[:80])
+        raise
+
+
+def verify_password_user(email_normalized: str, password_plain: str) -> Optional[str]:
+    """
+    Return ``user_id`` when credentials match, else ``None``.
+    """
+    row = get_password_user_by_email(email_normalized)
+    if not row:
+        return None
+    try:
+        ok = bcrypt.checkpw(
+            password_plain.encode("utf-8"),
+            row["password_hash"].encode("ascii"),
+        )
+    except Exception:
+        logger.exception("verify_password_user bcrypt failed user_id=%r", row["user_id"][:40])
+        return None
+    return row["user_id"] if ok else None
 
 
 def register_signup_user_id(user_id: str) -> None:

--- a/backend/db.py
+++ b/backend/db.py
@@ -22,6 +22,12 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+_BCRYPT_PASSWORD_MAX_BYTES = 72
+
+
+def _password_within_bcrypt_limit(password_plain: str) -> bool:
+    return len(password_plain.encode("utf-8")) <= _BCRYPT_PASSWORD_MAX_BYTES
+
 _local_wardrobes: dict[str, List[GarmentItem]] = {}
 _local_measurements: dict[str, BodyMeasurements] = {}
 # OAuth logins (no Supabase Auth): POST /analytics/register fills this in local dev.
@@ -130,6 +136,8 @@ def create_password_user(email_normalized: str, password_plain: str) -> Password
     if not is_valid_login_email(email_normalized):
         raise ValueError("invalid_email")
     if len(password_plain) < 8:
+        raise ValueError("weak_password")
+    if not _password_within_bcrypt_limit(password_plain):
         raise ValueError("weak_password")
 
     if get_password_user_by_email(email_normalized):

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ from .models import (
     MediaType,
     WeekEvent,
 )
-from .routers import analytics_router, recommendations, weather_router, calendar_router
+from .routers import analytics_router, auth_router, recommendations, weather_router, calendar_router
 from .routers.analytics_router import public_metrics_router
 from .storage import get_wardrobe, get_week_events as _storage_get_week_events, store_week_events
 
@@ -71,6 +71,7 @@ app.add_middleware(
 )
 
 app.include_router(recommendations.router)
+app.include_router(auth_router.router)
 app.include_router(weather_router.router)
 app.include_router(calendar_router.router)
 app.include_router(analytics_router.router)

--- a/backend/routers/analytics_router.py
+++ b/backend/routers/analytics_router.py
@@ -30,7 +30,7 @@ class AnalyticsSummaryResponse(BaseModel):
         description="max(Auth users, analytics_registered_users from POST /analytics/register, distinct wardrobe user_id)."
     )
     active_users: int = Field(
-        description="GA4 activeUsers over the rolling ``period_days`` window."
+        description="GA4 activeUsers over the rolling ``period_days`` window (all property traffic)."
     )
     waitlist: int = Field(
         description="Formspree submission count, or CSV URL rows, or Supabase waitlist table (see env docs)."

--- a/backend/routers/auth_router.py
+++ b/backend/routers/auth_router.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from ..db import (
+    create_password_user,
+    get_password_user_by_email,
+    is_valid_login_email,
+    normalize_login_email,
+    verify_password_user,
+)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class RegisterBody(BaseModel):
+    email: str = Field(..., min_length=3, max_length=254)
+    password: str = Field(..., min_length=8, max_length=256)
+
+
+class LoginBody(BaseModel):
+    email: str = Field(..., min_length=3, max_length=254)
+    password: str = Field(..., min_length=1, max_length=256)
+
+
+class AuthSuccessResponse(BaseModel):
+    user_id: str
+    email: str
+
+
+@router.post("/register", response_model=AuthSuccessResponse, status_code=201)
+def register_email_password(body: RegisterBody) -> AuthSuccessResponse:
+    normalized = normalize_login_email(body.email)
+    if not is_valid_login_email(normalized):
+        raise HTTPException(status_code=400, detail="Invalid email address.")
+    try:
+        row = create_password_user(normalized, body.password)
+    except ValueError as exc:
+        code = str(exc)
+        if code == "email_taken":
+            raise HTTPException(status_code=409, detail="An account with this email already exists.") from exc
+        if code == "weak_password":
+            raise HTTPException(
+                status_code=400,
+                detail="Password must be at least 8 characters.",
+            ) from exc
+        if code == "invalid_email":
+            raise HTTPException(status_code=400, detail="Invalid email address.") from exc
+        raise HTTPException(status_code=400, detail="Could not create account.") from exc
+    except Exception as exc:
+        if get_password_user_by_email(normalized):
+            raise HTTPException(status_code=409, detail="An account with this email already exists.") from exc
+        raise HTTPException(status_code=503, detail="Registration failed. Please try again.") from exc
+    return AuthSuccessResponse(user_id=row["user_id"], email=row["email"])
+
+
+@router.post("/login", response_model=AuthSuccessResponse)
+def login_email_password(body: LoginBody) -> AuthSuccessResponse:
+    normalized = normalize_login_email(body.email)
+    if not is_valid_login_email(normalized):
+        raise HTTPException(status_code=400, detail="Invalid email address.")
+    user_id = verify_password_user(normalized, body.password)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Incorrect email or password.")
+    return AuthSuccessResponse(user_id=user_id, email=normalized)

--- a/backend/tests/test_integration/test_auth_routes.py
+++ b/backend/tests/test_integration/test_auth_routes.py
@@ -1,0 +1,73 @@
+"""Email/password auth routes (isolated app — avoids importing ``backend.main`` / vision stack)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from backend.routers import auth_router
+
+
+@pytest.mark.usefixtures("_isolate_env")
+class TestAuthRoutes:
+    async def _client(self):
+        app = FastAPI()
+        app.include_router(auth_router.router)
+        transport = ASGITransport(app=app)
+        return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+    async def test_register_and_login(self, monkeypatch):
+        c = await self._client()
+        async with c:
+            r = await c.post(
+                "/auth/register",
+                json={"email": "  Hello@Example.COM ", "password": "hunter42!"},
+            )
+            assert r.status_code == 201
+            data = r.json()
+            assert data["email"] == "hello@example.com"
+            assert data["user_id"] == "email-hello-at-example-dot-com"
+
+            login = await c.post(
+                "/auth/login",
+                json={"email": "hello@example.com", "password": "hunter42!"},
+            )
+            assert login.status_code == 200
+            assert login.json()["user_id"] == data["user_id"]
+
+    async def test_register_duplicate(self, monkeypatch):
+        c = await self._client()
+        async with c:
+            await c.post(
+                "/auth/register",
+                json={"email": "dup@example.com", "password": "password1"},
+            )
+            r2 = await c.post(
+                "/auth/register",
+                json={"email": "dup@example.com", "password": "otherpass1"},
+            )
+            assert r2.status_code == 409
+
+    async def test_login_wrong_password(self, monkeypatch):
+        c = await self._client()
+        async with c:
+            await c.post(
+                "/auth/register",
+                json={"email": "u@example.com", "password": "correct12"},
+            )
+            bad = await c.post(
+                "/auth/login",
+                json={"email": "u@example.com", "password": "wrongpass"},
+            )
+            assert bad.status_code == 401
+
+    async def test_register_weak_password(self, monkeypatch):
+        c = await self._client()
+        async with c:
+            r = await c.post(
+                "/auth/register",
+                json={"email": "x@example.com", "password": "short"},
+            )
+            assert r.status_code in (400, 422)

--- a/backend/tests/test_unit/test_analytics.py
+++ b/backend/tests/test_unit/test_analytics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from backend import analytics_metrics as am
 from backend.analytics_metrics import (
     _csv_row_is_nonempty,
     _env_truthy,
@@ -65,6 +66,21 @@ class TestBuildAnalyticsSummary:
         monkeypatch.setenv("ANALYTICS_USE_DUMMY_METRICS", "true")
         summary = build_analytics_summary(period_days=9999)
         assert summary["period_days"] == 366
+
+    def test_active_users_is_raw_ga4_not_capped_vs_signups(self, monkeypatch):
+        monkeypatch.delenv("ANALYTICS_USE_DUMMY_METRICS", raising=False)
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+        monkeypatch.delenv("FORMSPREE_FORM_ID", raising=False)
+        monkeypatch.delenv("WAITLIST_SHEET_CSV_URL", raising=False)
+        monkeypatch.setattr(am, "count_signups", lambda: 18)
+        monkeypatch.setattr(am, "count_waitlist_rows", lambda: 0)
+        monkeypatch.setattr(am, "fetch_ga4_screen_metrics", lambda days: (200, 45))
+
+        summary = build_analytics_summary(period_days=28)
+        assert summary["signups"] == 18
+        assert summary["active_users"] == 45
+        assert summary["page_views"] == 200
 
 
 class TestCountSignups:

--- a/misfitai-mobile/package-lock.json
+++ b/misfitai-mobile/package-lock.json
@@ -3160,7 +3160,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4215,7 +4215,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -10225,7 +10225,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/misfitai-mobile/src/AppStateContext.tsx
+++ b/misfitai-mobile/src/AppStateContext.tsx
@@ -260,7 +260,9 @@ export function AppStateProvider({
 
   const syncCalendarEvents = useCallback(async () => {
     if (!googleAccessToken) {
-      throw new Error('No Google access token available. Please sign in with Google again.');
+      throw new Error(
+        'Calendar sync needs Google sign-in with calendar access. Use “Use demo week” or pick event types for each day instead.'
+      );
     }
     let result;
     try {

--- a/misfitai-mobile/src/AuthScreen.tsx
+++ b/misfitai-mobile/src/AuthScreen.tsx
@@ -484,7 +484,7 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   errorText: {
-    color: '#b42318',
+    color: palette.error,
     fontSize: 13,
     fontFamily: type.bodyMedium,
     marginTop: 6,

--- a/misfitai-mobile/src/AuthScreen.tsx
+++ b/misfitai-mobile/src/AuthScreen.tsx
@@ -1,15 +1,20 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  ActivityIndicator,
   Animated,
+  KeyboardAvoidingView,
   Platform,
   Pressable,
   SafeAreaView,
+  ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import * as Google from 'expo-auth-session/providers/google';
+import { getApiErrorMessage, loginEmailPassword, registerEmailPassword } from './api';
 import { AtmosphereBackground } from './AtmosphereBackground';
 import { palette, radius, type } from './theme';
 
@@ -20,7 +25,7 @@ const AppleAuthentication =
 WebBrowser.maybeCompleteAuthSession();
 
 export type AuthMode = 'login' | 'signup';
-export type AuthProvider = 'apple' | 'google';
+export type AuthProvider = 'apple' | 'google' | 'email';
 
 /** Profile we collect from Google (People API) or Apple. Used for styling and DB user identity. */
 export type UserProfile = {
@@ -69,6 +74,10 @@ export function AuthScreen({
 }) {
   const [mode, setMode] = useState<AuthMode>('login');
   const [loadingProvider, setLoadingProvider] = useState<AuthProvider | null>(null);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
 
   // Pass a placeholder ID when unconfigured so the hook doesn't throw.
   // The button is disabled via `googleConfigured` below.
@@ -194,6 +203,47 @@ export function AuthScreen({
     }
   }, [googlePromptAsync]);
 
+  useEffect(() => {
+    setEmailError(null);
+  }, [mode]);
+
+  const handleEmailAuth = useCallback(async () => {
+    setEmailError(null);
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail || !trimmedEmail.includes('@')) {
+      setEmailError('Enter a valid email address.');
+      return;
+    }
+    if (password.length < 8) {
+      setEmailError('Password must be at least 8 characters.');
+      return;
+    }
+    if (mode === 'signup' && password !== confirmPassword) {
+      setEmailError('Passwords do not match.');
+      return;
+    }
+    try {
+      setLoadingProvider('email');
+      const result =
+        mode === 'signup'
+          ? await registerEmailPassword(trimmedEmail, password)
+          : await loginEmailPassword(trimmedEmail, password);
+      const profile: UserProfile = {
+        id: result.userId,
+        email: result.email,
+        displayName: null,
+        photoUrl: null,
+        gender: null,
+        birthday: null,
+      };
+      onAuthenticated('email', mode, profile);
+    } catch (err: unknown) {
+      setEmailError(getApiErrorMessage(err, mode === 'signup' ? 'Could not sign up.' : 'Could not sign in.'));
+    } finally {
+      setLoadingProvider(null);
+    }
+  }, [confirmPassword, email, mode, onAuthenticated, password]);
+
   const animatedStyle = {
     opacity: entrance,
     transform: [
@@ -206,69 +256,142 @@ export function AuthScreen({
     ],
   };
 
+  const busy = loadingProvider !== null;
+
   return (
     <SafeAreaView style={styles.safe}>
       <AtmosphereBackground />
-      <Animated.View style={[styles.container, animatedStyle]}>
-        <View style={styles.header}>
-          <Text style={styles.brand}>misfitAI</Text>
-          <Text style={styles.title}>
-            {mode === 'login' ? 'Welcome back' : 'Create your account'}
-          </Text>
-          <Text style={styles.subtitle}>
-            {mode === 'login'
-              ? 'Sign in to continue planning your weekly looks.'
-              : 'Sign up to start building your digital wardrobe.'}
-          </Text>
-        </View>
-
-        <View style={styles.modeSwitch}>
-          <Pressable
-            onPress={() => setMode('login')}
-            style={[styles.modeButton, mode === 'login' && styles.modeButtonActive]}
-          >
-            <Text style={[styles.modeButtonText, mode === 'login' && styles.modeButtonTextActive]}>
-              Log in
-            </Text>
-          </Pressable>
-          <Pressable
-            onPress={() => setMode('signup')}
-            style={[styles.modeButton, mode === 'signup' && styles.modeButtonActive]}
-          >
-            <Text style={[styles.modeButtonText, mode === 'signup' && styles.modeButtonTextActive]}>
-              Sign up
-            </Text>
-          </Pressable>
-        </View>
-
-        <View style={styles.authCard}>
-          {Platform.OS === 'ios' && (
-            <Pressable
-              onPress={handleAppleAuth}
-              disabled={loadingProvider !== null}
-              style={[styles.providerButton, styles.providerButtonPrimary]}
-            >
-              <Text style={styles.providerButtonPrimaryText}>
-                {loadingProvider === 'apple' ? 'Connecting Apple...' : 'Continue with Apple'}
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <Animated.View style={[styles.container, animatedStyle]}>
+            <View style={styles.header}>
+              <Text style={styles.brand}>misfitAI</Text>
+              <Text style={styles.title}>
+                {mode === 'login' ? 'Welcome back' : 'Create your account'}
               </Text>
-            </Pressable>
-          )}
+              <Text style={styles.subtitle}>
+                {mode === 'login'
+                  ? 'Sign in to continue planning your weekly looks.'
+                  : 'Sign up to start building your digital wardrobe.'}
+              </Text>
+            </View>
 
-          <Pressable
-            onPress={handleGoogleAuth}
-            disabled={loadingProvider !== null || !googleRequest || !googleConfigured}
-            style={[styles.providerButton, !googleConfigured && { opacity: 0.4 }]}
-          >
-            <Text style={styles.providerButtonText}>
-              {!googleConfigured
-                ? 'Google (client ID not configured)'
-                : loadingProvider === 'google'
-                  ? 'Connecting Google...'
-                  : 'Continue with Google'}
-            </Text>
-          </Pressable>
-        </View>
-      </Animated.View>
+            <View style={styles.modeSwitch}>
+              <Pressable
+                onPress={() => setMode('login')}
+                style={[styles.modeButton, mode === 'login' && styles.modeButtonActive]}
+              >
+                <Text style={[styles.modeButtonText, mode === 'login' && styles.modeButtonTextActive]}>
+                  Log in
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={() => setMode('signup')}
+                style={[styles.modeButton, mode === 'signup' && styles.modeButtonActive]}
+              >
+                <Text style={[styles.modeButtonText, mode === 'signup' && styles.modeButtonTextActive]}>
+                  Sign up
+                </Text>
+              </Pressable>
+            </View>
+
+            <View style={styles.authCard}>
+              <Text style={styles.sectionLabel}>Email</Text>
+              <TextInput
+                value={email}
+                onChangeText={setEmail}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="email-address"
+                textContentType="emailAddress"
+                placeholder="you@example.com"
+                placeholderTextColor={palette.muted}
+                editable={!busy}
+                style={styles.input}
+              />
+              <Text style={styles.sectionLabel}>Password</Text>
+              <TextInput
+                value={password}
+                onChangeText={setPassword}
+                secureTextEntry
+                textContentType={mode === 'login' ? 'password' : 'newPassword'}
+                placeholder="At least 8 characters"
+                placeholderTextColor={palette.muted}
+                editable={!busy}
+                style={styles.input}
+              />
+              {mode === 'signup' ? (
+                <>
+                  <Text style={styles.sectionLabel}>Confirm password</Text>
+                  <TextInput
+                    value={confirmPassword}
+                    onChangeText={setConfirmPassword}
+                    secureTextEntry
+                    textContentType="newPassword"
+                    placeholder="Re-enter password"
+                    placeholderTextColor={palette.muted}
+                    editable={!busy}
+                    style={styles.input}
+                  />
+                </>
+              ) : null}
+
+              {emailError ? <Text style={styles.errorText}>{emailError}</Text> : null}
+
+              <Pressable
+                onPress={handleEmailAuth}
+                disabled={busy}
+                style={[styles.providerButton, styles.providerButtonPrimary, busy && styles.buttonDisabled]}
+              >
+                {loadingProvider === 'email' ? (
+                  <ActivityIndicator color={palette.textOnAccent} />
+                ) : (
+                  <Text style={styles.providerButtonPrimaryText}>
+                    {mode === 'signup' ? 'Create account' : 'Continue with email'}
+                  </Text>
+                )}
+              </Pressable>
+            </View>
+
+            <Text style={styles.dividerLabel}>or continue with</Text>
+
+            <View style={styles.authCard}>
+              {Platform.OS === 'ios' && (
+                <Pressable
+                  onPress={handleAppleAuth}
+                  disabled={busy}
+                  style={[styles.providerButton, styles.providerButtonPrimary, busy && styles.buttonDisabled]}
+                >
+                  <Text style={styles.providerButtonPrimaryText}>
+                    {loadingProvider === 'apple' ? 'Connecting Apple...' : 'Continue with Apple'}
+                  </Text>
+                </Pressable>
+              )}
+
+              <Pressable
+                onPress={handleGoogleAuth}
+                disabled={busy || !googleRequest || !googleConfigured}
+                style={[styles.providerButton, !googleConfigured && { opacity: 0.4 }, busy && styles.buttonDisabled]}
+              >
+                <Text style={styles.providerButtonText}>
+                  {!googleConfigured
+                    ? 'Google (client ID not configured)'
+                    : loadingProvider === 'google'
+                      ? 'Connecting Google...'
+                      : 'Continue with Google'}
+                </Text>
+              </Pressable>
+            </View>
+          </Animated.View>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
@@ -277,6 +400,13 @@ const styles = StyleSheet.create({
   safe: {
     flex: 1,
     backgroundColor: palette.bg,
+  },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingBottom: 32,
   },
   container: {
     flex: 1,
@@ -334,6 +464,39 @@ const styles = StyleSheet.create({
   modeButtonTextActive: {
     color: palette.textOnAccent,
   },
+  sectionLabel: {
+    fontSize: 12,
+    fontFamily: type.bodyDemi,
+    color: palette.inkSoft,
+    marginBottom: 4,
+    marginTop: 4,
+  },
+  input: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 14,
+    paddingVertical: Platform.OS === 'ios' ? 12 : 10,
+    fontSize: 15,
+    fontFamily: type.body,
+    color: palette.ink,
+    marginBottom: 4,
+  },
+  errorText: {
+    color: '#b42318',
+    fontSize: 13,
+    fontFamily: type.bodyMedium,
+    marginTop: 6,
+    marginBottom: 4,
+  },
+  dividerLabel: {
+    textAlign: 'center',
+    fontSize: 12,
+    fontFamily: type.bodyMedium,
+    color: palette.muted,
+    marginVertical: 12,
+  },
   authCard: {
     borderRadius: 24,
     borderWidth: 1,
@@ -341,6 +504,9 @@ const styles = StyleSheet.create({
     backgroundColor: palette.panel,
     padding: 14,
     gap: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.55,
   },
   providerButton: {
     borderRadius: radius.pill,

--- a/misfitai-mobile/src/EventsScreen.tsx
+++ b/misfitai-mobile/src/EventsScreen.tsx
@@ -155,6 +155,12 @@ export function EventsScreen({
         <Text style={styles.screenSubtitle}>
           Set one event per day and generate seven minimalist looks from your wardrobe.
         </Text>
+        <Text style={styles.calendarExplainer}>
+          Live calendar import uses Google Calendar and only works when you signed in with Google (with
+          calendar access). Otherwise use{' '}
+          <Text style={styles.calendarExplainerEm}>Use demo week</Text> or tap an event type for each
+          day — no Google required.
+        </Text>
 
         <View style={styles.actionsRow}>
           <Pressable
@@ -280,6 +286,17 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     color: palette.muted,
     fontFamily: type.body,
+  },
+  calendarExplainer: {
+    fontSize: 13,
+    lineHeight: 19,
+    color: palette.muted,
+    fontFamily: type.body,
+    marginTop: 6,
+  },
+  calendarExplainerEm: {
+    fontFamily: type.bodyDemi,
+    color: palette.inkSoft,
   },
   actionsRow: {
     marginTop: 2,

--- a/misfitai-mobile/src/ProfileSetupScreen.tsx
+++ b/misfitai-mobile/src/ProfileSetupScreen.tsx
@@ -81,8 +81,7 @@ export function ProfileSetupScreen({
         <Text style={styles.brand}>misfitAI</Text>
         <Text style={styles.title}>A quick question</Text>
         <Text style={styles.subtitle}>
-          We no longer pull birthday or gender from Google. Add them here (optional) so we can
-          personalize your experience.
+          Optional — helps tailor recommendations.
         </Text>
 
         <View style={styles.card}>

--- a/misfitai-mobile/src/__tests__/AuthScreen.test.tsx
+++ b/misfitai-mobile/src/__tests__/AuthScreen.test.tsx
@@ -10,14 +10,8 @@ describe('AuthScreen', () => {
   });
 
   it('renders the sign-in heading', () => {
-    const { getByText } = render(
-      <AuthScreen onAuthenticated={mockOnAuthenticated} />,
-    );
-    // The screen should contain some auth-related text
-    const screen = render(
-      <AuthScreen onAuthenticated={mockOnAuthenticated} />,
-    );
-    expect(screen.toJSON()).toBeTruthy();
+    const { getByText } = render(<AuthScreen onAuthenticated={mockOnAuthenticated} />);
+    expect(getByText('Welcome back')).toBeTruthy();
   });
 
   it('renders Google sign-in button', () => {
@@ -33,10 +27,14 @@ describe('AuthScreen', () => {
     expect(mockOnAuthenticated).not.toHaveBeenCalled();
   });
 
-  it('renders without crashing with mode prop', () => {
-    const { toJSON } = render(
-      <AuthScreen onAuthenticated={mockOnAuthenticated} mode="signup" />,
-    );
-    expect(toJSON()).toBeTruthy();
+  it('switches to sign up copy when Sign up is pressed', () => {
+    const { getByText } = render(<AuthScreen onAuthenticated={mockOnAuthenticated} />);
+    fireEvent.press(getByText('Sign up'));
+    expect(getByText('Create your account')).toBeTruthy();
+  });
+
+  it('shows email fields', () => {
+    const { getByPlaceholderText } = render(<AuthScreen onAuthenticated={mockOnAuthenticated} />);
+    expect(getByPlaceholderText('you@example.com')).toBeTruthy();
   });
 });

--- a/misfitai-mobile/src/api.ts
+++ b/misfitai-mobile/src/api.ts
@@ -31,6 +31,91 @@ const VISION_REQUEST_RETRIES = 2;
 const VISION_RETRY_BACKOFF_MS = 450;
 const VISION_FILE_FETCH_TIMEOUT_MS = 45000;
 
+export interface EmailAuthResult {
+  userId: string;
+  email: string;
+}
+
+const mockEmailPasswordStore = new Map<string, string>();
+
+function deriveEmailUserId(emailNormalized: string): string {
+  return `email-${emailNormalized.replace(/@/g, '-at-').replace(/\./g, '-dot-')}`;
+}
+
+/** Register with email + password (persists via ``POST /auth/register`` when not using mock API). */
+export async function registerEmailPassword(
+  email: string,
+  password: string
+): Promise<EmailAuthResult> {
+  const trimmed = email.trim();
+  if (USE_MOCK_API) {
+    const normalized = trimmed.toLowerCase();
+    if (mockEmailPasswordStore.has(normalized)) {
+      throw new ApiError('Account exists', 409, JSON.stringify({ detail: 'exists' }));
+    }
+    mockEmailPasswordStore.set(normalized, password);
+    return { userId: deriveEmailUserId(normalized), email: normalized };
+  }
+
+  const response = await fetch(`${API_BASE_URL}/auth/register`, {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: trimmed, password }),
+  });
+  const rawBody = await response.text();
+  if (!response.ok) {
+    throw new ApiError(
+      `API request failed: ${response.status} ${response.statusText}`,
+      response.status,
+      rawBody
+    );
+  }
+  const data = JSON.parse(rawBody) as { user_id?: string; email?: string };
+  const userId = (data.user_id || '').trim();
+  const normalizedEmail = (data.email || '').trim().toLowerCase();
+  if (!userId || !normalizedEmail) {
+    throw new ApiError('Invalid auth response', 502, rawBody);
+  }
+  return { userId, email: normalizedEmail };
+}
+
+/** Log in with email + password (``POST /auth/login``). */
+export async function loginEmailPassword(
+  email: string,
+  password: string
+): Promise<EmailAuthResult> {
+  const trimmed = email.trim();
+  if (USE_MOCK_API) {
+    const normalized = trimmed.toLowerCase();
+    const stored = mockEmailPasswordStore.get(normalized);
+    if (!stored || stored !== password) {
+      throw new ApiError('Invalid credentials', 401, JSON.stringify({ detail: 'invalid' }));
+    }
+    return { userId: deriveEmailUserId(normalized), email: normalized };
+  }
+
+  const response = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: trimmed, password }),
+  });
+  const rawBody = await response.text();
+  if (!response.ok) {
+    throw new ApiError(
+      `API request failed: ${response.status} ${response.statusText}`,
+      response.status,
+      rawBody
+    );
+  }
+  const data = JSON.parse(rawBody) as { user_id?: string; email?: string };
+  const userId = (data.user_id || '').trim();
+  const normalizedEmail = (data.email || '').trim().toLowerCase();
+  if (!userId || !normalizedEmail) {
+    throw new ApiError('Invalid auth response', 502, rawBody);
+  }
+  return { userId, email: normalizedEmail };
+}
+
 /** After OAuth login, record user for GET /api/metrics ``signups`` (no wardrobe required). */
 export function registerSignupWithBackend(userId: string): void {
   if (!userId?.trim() || USE_MOCK_API) return;

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ Pillow
 pillow-heif
 python-multipart
 supabase
+bcrypt
 google-analytics-data
 
 # Testing

--- a/scripts/sql/app_users.sql
+++ b/scripts/sql/app_users.sql
@@ -6,10 +6,11 @@ create table if not exists public.app_users (
   email text not null unique,
   password_hash text not null,
   created_at timestamptz not null default now(),
-  updated_at timestamptz not null default now()
+  updated_at timestamptz not null default now(),
+  constraint app_users_email_lower_chk check (email = lower(email))
 );
 
-create index if not exists app_users_email_lower_idx on public.app_users (lower(email));
+create unique index if not exists app_users_email_lower_idx on public.app_users (lower(email));
 
 comment on table public.app_users is
   'Email/password signups; user_id matches app wardrobe API key (email-… slug).';

--- a/scripts/sql/app_users.sql
+++ b/scripts/sql/app_users.sql
@@ -1,0 +1,15 @@
+-- Email + password accounts for the mobile app (server verifies credentials; not Supabase Auth).
+-- Run in Supabase SQL editor once.
+
+create table if not exists public.app_users (
+  user_id text primary key,
+  email text not null unique,
+  password_hash text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists app_users_email_lower_idx on public.app_users (lower(email));
+
+comment on table public.app_users is
+  'Email/password signups; user_id matches app wardrobe API key (email-… slug).';


### PR DESCRIPTION
## Summary
- Add **email + password authentication** end-to-end (backend routes + mobile UI + shared user_id derivation).
- Introduce **Supabase-backed `app_users` table** (with local fallback) to store bcrypt password hashes and support login/registration.
- Clarify analytics semantics so **GA4 active users/page views are raw property traffic** (not capped to signups).

## Changes
- **Backend**
  - Add `POST /auth/register` and `POST /auth/login` (`backend/routers/auth_router.py`).
  - Add password-user storage helpers in `backend/db.py` (email normalization/validation, bcrypt hashing + verify, Supabase table + local fallback).
  - Wire auth router into app (`backend/main.py`).
  - Update analytics docs/response descriptions and unit test to ensure GA4 `active_users` isn’t capped vs `signups`.

- **Mobile**
  - Add Email auth UI to `AuthScreen` (email/password + confirm password on signup; error copy + loading states; keyboard-safe scrolling).
  - Add `registerEmailPassword` / `loginEmailPassword` API helpers with mock-mode support (`misfitai-mobile/src/api.ts`).
  - Improve calendar-sync guidance text when Google Calendar isn’t available (`AppStateContext`, `EventsScreen`).
  - Minor copy tweak in profile setup screen; update `AuthScreen` tests accordingly.

- **DB / Infra**
  - Add `scripts/sql/app_users.sql` to create `public.app_users` (unique email, password_hash, timestamps, lower(email) index).
  - Add `bcrypt` to `requirements.txt`.

## Test plan
- `pytest backend/tests/test_unit/test_analytics.py -k active_users`
- `pytest backend/tests/test_integration/test_auth_routes.py`
- In the app: verify **Sign up / Login with email** works; verify **Google-only calendar sync** messaging and fallbacks (“Use demo week” / manual event types).

## Notes
- Email `user_id` is deterministic (`email-<normalized email slug>`) to match the mobile app’s derived ID scheme.
- `active_users` reflects **all GA4 property traffic** (including anonymous), so it can exceed app signups.

## Screenshots of UI
**Login Page:**
<img height="1506" alt="image" src="https://github.com/user-attachments/assets/259cbba0-08ce-450d-bd5f-332375a92ed5" />

**Sign Up Page:**
<img height="1506" alt="image" src="https://github.com/user-attachments/assets/43a363fb-e1c7-476b-8721-f76e54742b79" />

**Asking Info (Optional) Page:**
<img height="1648" alt="image" src="https://github.com/user-attachments/assets/cce9d527-9041-432e-a771-2baab8396587" />

**Calendar Connect Page:**
<img height="1438" alt="image" src="https://github.com/user-attachments/assets/9c2d288b-31c5-41eb-af61-5900800f9927" />