### PR TITLE
Profile‑Driven Onboarding (Measurements, Tones, Bitmoji Seed)

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -11,12 +11,14 @@ import bcrypt
 from supabase import Client, create_client
 
 from .models import (
+    AvatarConfig,
     BodyMeasurements,
     GarmentCategory,
     GarmentFormality,
     GarmentGender,
     GarmentItem,
     GarmentSeasonality,
+    UserProfile,
     build_garment_tags,
 )
 
@@ -30,6 +32,7 @@ def _password_within_bcrypt_limit(password_plain: str) -> bool:
 
 _local_wardrobes: dict[str, List[GarmentItem]] = {}
 _local_measurements: dict[str, BodyMeasurements] = {}
+_local_user_profiles: dict[str, UserProfile] = {}
 # OAuth logins (no Supabase Auth): POST /analytics/register fills this in local dev.
 _local_signup_user_ids: set[str] = set()
 # Email/password users when Supabase is unavailable or table writes fall back (see create_password_user).
@@ -69,6 +72,10 @@ def _table_name() -> str:
 
 def _measurements_table_name() -> str:
     return os.getenv("SUPABASE_MEASUREMENTS_TABLE", "user_measurements")
+
+
+def _profiles_table_name() -> str:
+    return os.getenv("SUPABASE_PROFILES_TABLE", "user_profiles")
 
 
 def _signup_registry_table() -> str:
@@ -691,3 +698,106 @@ def _row_to_measurements(row: dict[str, Any]) -> BodyMeasurements:
         inseam_cm=_float_or_none("inseam_cm"),
         updated_at=_parse_datetime(row.get("updated_at")),
     )
+
+
+# ---------------------------------------------------------------------------
+# User profile (style preferences, sizes, avatar)
+# ---------------------------------------------------------------------------
+
+
+def _row_to_user_profile(row: dict[str, Any]) -> UserProfile:
+    """Deserialise a Supabase ``user_profiles`` row into a :class:`UserProfile`."""
+    avatar_raw = row.get("avatar_config")
+    avatar: Optional[AvatarConfig] = None
+    if isinstance(avatar_raw, dict):
+        avatar = AvatarConfig(
+            hair_style=avatar_raw.get("hair_style"),
+            hair_color=avatar_raw.get("hair_color"),
+            body_type=avatar_raw.get("body_type"),
+            skin_tone=avatar_raw.get("skin_tone"),
+        )
+
+    def _str_list(key: str) -> list[str]:
+        v = row.get(key)
+        if isinstance(v, list):
+            return [str(x) for x in v]
+        return []
+
+    return UserProfile(
+        user_id=str(row.get("user_id", "")),
+        gender=row.get("gender"),
+        birthday=row.get("birthday"),
+        skin_tone=row.get("skin_tone"),
+        color_tone=row.get("color_tone"),
+        favorite_colors=_str_list("favorite_colors"),
+        avoided_colors=_str_list("avoided_colors"),
+        shoe_size=row.get("shoe_size"),
+        top_size=row.get("top_size"),
+        bottom_size=row.get("bottom_size"),
+        avatar_config=avatar,
+        updated_at=_parse_datetime(row.get("updated_at")),
+    )
+
+
+def get_user_profile(user_id: str) -> Optional[UserProfile]:
+    """Return the style profile for *user_id*, or ``None`` if not yet created."""
+    if _use_local_store():
+        return _local_user_profiles.get(user_id)
+    try:
+        result = (
+            get_supabase_client()
+            .table(_profiles_table_name())
+            .select("*")
+            .eq("user_id", user_id)
+            .limit(1)
+            .execute()
+        )
+        rows = result.data or []
+        if not rows:
+            return None
+        return _row_to_user_profile(rows[0])
+    except Exception:
+        logger.exception("get_user_profile failed user_id=%s", user_id)
+        return None
+
+
+def upsert_user_profile(user_id: str, data: dict[str, Any]) -> UserProfile:
+    """
+    Create or update the style profile for *user_id*.
+
+    *data* may be a partial dict — only provided keys are written.  The
+    ``user_id`` and ``updated_at`` fields are always set automatically.
+    """
+    now = datetime.utcnow()
+    payload: dict[str, Any] = {k: v for k, v in data.items() if k not in ("user_id", "updated_at")}
+    payload["user_id"] = user_id
+    payload["updated_at"] = now.isoformat()
+
+    # Serialise avatar_config to a plain dict for Supabase jsonb.
+    if "avatar_config" in payload and isinstance(payload["avatar_config"], AvatarConfig):
+        payload["avatar_config"] = payload["avatar_config"].model_dump(mode="json", exclude_none=True)
+
+    if _use_local_store():
+        existing = _local_user_profiles.get(user_id)
+        if existing:
+            merged = existing.model_dump()
+            merged.update(payload)
+            profile = _row_to_user_profile(merged)
+        else:
+            profile = _row_to_user_profile(payload)
+        _local_user_profiles[user_id] = profile
+        return profile
+
+    try:
+        result = (
+            get_supabase_client()
+            .table(_profiles_table_name())
+            .upsert(payload, on_conflict="user_id")
+            .execute()
+        )
+        row = (result.data or [payload])[0]
+        return _row_to_user_profile(row)
+    except Exception:
+        logger.exception("upsert_user_profile failed user_id=%s", user_id)
+        # Return a best-effort object so callers don't crash.
+        return _row_to_user_profile(payload)

--- a/backend/db.py
+++ b/backend/db.py
@@ -715,6 +715,7 @@ def _row_to_user_profile(row: dict[str, Any]) -> UserProfile:
             hair_color=avatar_raw.get("hair_color"),
             body_type=avatar_raw.get("body_type"),
             skin_tone=avatar_raw.get("skin_tone"),
+            avatar_image_url=avatar_raw.get("avatar_image_url"),
         )
 
     def _str_list(key: str) -> list[str]:

--- a/backend/db.py
+++ b/backend/db.py
@@ -715,7 +715,6 @@ def _row_to_user_profile(row: dict[str, Any]) -> UserProfile:
             hair_color=avatar_raw.get("hair_color"),
             body_type=avatar_raw.get("body_type"),
             skin_tone=avatar_raw.get("skin_tone"),
-            avatar_image_url=avatar_raw.get("avatar_image_url"),
         )
 
     def _str_list(key: str) -> list[str]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ from .models import (
     MediaType,
     WeekEvent,
 )
-from .routers import analytics_router, auth_router, recommendations, weather_router, calendar_router
+from .routers import analytics_router, auth_router, recommendations, weather_router, calendar_router, profile_router
 from .routers.analytics_router import public_metrics_router
 from .storage import get_wardrobe, get_week_events as _storage_get_week_events, store_week_events
 
@@ -76,6 +76,7 @@ app.include_router(weather_router.router)
 app.include_router(calendar_router.router)
 app.include_router(analytics_router.router)
 app.include_router(public_metrics_router)
+app.include_router(profile_router.router)
 
 _local_assets_dir = Path(os.getenv("LOCAL_GARMENTS_DIR", "outputs/local_garments"))
 _local_assets_dir.mkdir(parents=True, exist_ok=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -142,6 +142,72 @@ class MediaIngestionJob(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# User profile (style preferences, sizes, avatar)
+# ---------------------------------------------------------------------------
+
+
+class AvatarConfig(BaseModel):
+    """Bitmoji-style avatar configuration stored as a structured JSON object."""
+
+    hair_style: Optional[str] = None
+    """E.g. ``"short_wavy"``, ``"long_straight"``, ``"curly_afro"``."""
+
+    hair_color: Optional[str] = None
+    """E.g. ``"black"``, ``"blonde"``, ``"auburn"``."""
+
+    body_type: Optional[str] = None
+    """One of ``"slim"``, ``"average"``, ``"broad"``."""
+
+    skin_tone: Optional[str] = None
+    """One of ``"very_light"``, ``"light"``, ``"medium_light"``, ``"medium"``,
+    ``"medium_dark"``, ``"dark"``."""
+
+
+class UserProfile(BaseModel):
+    """
+    Extended style profile for a user.
+
+    Measurements (height, chest, etc.) live in :class:`BodyMeasurements`.
+    Auth identity lives in ``app_users``.
+    This model captures the subjective style data that powers personalised
+    colour/size filtering in the recommendation engine and the avatar feature.
+    """
+
+    user_id: str
+
+    # --- Personal ---
+    gender: Optional[str] = None
+    """``"male"``, ``"female"``, or ``"other"``."""
+    birthday: Optional[str] = None
+    """ISO date string ``YYYY-MM-DD``."""
+
+    # --- Appearance ---
+    skin_tone: Optional[str] = None
+    """One of ``"very_light"``, ``"light"``, ``"medium_light"``, ``"medium"``,
+    ``"medium_dark"``, ``"dark"``."""
+
+    color_tone: Optional[str] = None
+    """Broad colour temperature: ``"warm"``, ``"cool"``, or ``"neutral"``."""
+
+    # --- Colour preferences ---
+    favorite_colors: List[str] = []
+    """Colour names / hex codes the user wants prioritised in recommendations."""
+
+    avoided_colors: List[str] = []
+    """Colour names / hex codes the user wants de-prioritised or excluded."""
+
+    # --- Sizes ---
+    shoe_size: Optional[str] = None
+    top_size: Optional[str] = None
+    bottom_size: Optional[str] = None
+
+    # --- Avatar ---
+    avatar_config: Optional[AvatarConfig] = None
+
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
 # Body measurements
 # ---------------------------------------------------------------------------
 

--- a/backend/recommendation.py
+++ b/backend/recommendation.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from typing import Optional
 
 from .llm import generate_outfit_explanation
-from .models import BodyMeasurements, DayOutfitSuggestion, GarmentItem, WeekEvent
+from .models import BodyMeasurements, DayOutfitSuggestion, GarmentItem, UserProfile, WeekEvent
 
 # ---------------------------------------------------------------------------
 # Category sets — checked against both category.value and sub_category
@@ -171,6 +171,91 @@ def _size_matches(item: GarmentItem, user_size_label: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Colour-preference helpers
+# ---------------------------------------------------------------------------
+
+# Broad colour-family groupings used to map a garment's color_primary/secondary
+# to warm or cool categories.  Kept intentionally loose — the goal is soft
+# preference scoring, not hard exclusion.
+_WARM_COLOR_FAMILIES: frozenset[str] = frozenset(
+    {
+        "red", "orange", "yellow", "gold", "amber", "coral", "rust",
+        "terracotta", "brown", "beige", "tan", "camel", "sand",
+        "cream", "ivory", "olive", "mustard", "peach", "salmon",
+    }
+)
+
+_COOL_COLOR_FAMILIES: frozenset[str] = frozenset(
+    {
+        "blue", "navy", "indigo", "violet", "purple", "lilac", "lavender",
+        "teal", "cyan", "turquoise", "mint", "green", "sage", "emerald",
+        "grey", "gray", "silver", "white", "black",
+    }
+)
+
+# Score modifiers (added to a base score of 0.0)
+_COLOR_MATCH_BONUS = 0.5
+_COLOR_AVOID_PENALTY = -2.0
+_COLOR_TONE_BONUS = 0.2
+
+
+def _color_words(color_str: Optional[str]) -> frozenset[str]:
+    """Tokenise a colour string into normalised words for fuzzy matching."""
+    if not color_str:
+        return frozenset()
+    import re
+    return frozenset(re.split(r"[\s,/\-_]+", color_str.strip().lower()))
+
+
+def _score_color_preference(item: GarmentItem, profile: Optional[UserProfile]) -> float:
+    """
+    Return a floating-point colour score for *item* given *profile*.
+
+    Positive scores indicate colour preference alignment; negative scores
+    indicate colours the user explicitly wants to avoid.  Returns 0.0 when
+    no profile is provided or preferences are empty.
+
+    The score is additive and relative — it does not replace formality or
+    size scoring, but is factored in when selecting among otherwise-equal
+    candidates.
+    """
+    if profile is None:
+        return 0.0
+
+    item_words = _color_words(item.color_primary) | _color_words(item.color_secondary)
+    if not item_words:
+        return 0.0
+
+    score = 0.0
+
+    # Hard penalty for avoided colours — any word overlap triggers it.
+    if profile.avoided_colors:
+        avoid_words = frozenset(
+            w for c in profile.avoided_colors for w in _color_words(c)
+        )
+        if item_words & avoid_words:
+            score += _COLOR_AVOID_PENALTY
+
+    # Bonus for explicitly preferred colours.
+    if profile.favorite_colors:
+        fav_words = frozenset(
+            w for c in profile.favorite_colors for w in _color_words(c)
+        )
+        if item_words & fav_words:
+            score += _COLOR_MATCH_BONUS
+
+    # Soft bonus / mild penalty for colour tone alignment.
+    if profile.color_tone:
+        tone = profile.color_tone.lower()
+        if tone == "warm" and item_words & _WARM_COLOR_FAMILIES:
+            score += _COLOR_TONE_BONUS
+        elif tone == "cool" and item_words & _COOL_COLOR_FAMILIES:
+            score += _COLOR_TONE_BONUS
+
+    return score
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
@@ -227,16 +312,17 @@ def _pick_garment(
     used_ids: set[str],
     event_type: str = "",
     user_size_label: Optional[str] = None,
+    user_profile: Optional[UserProfile] = None,
 ) -> Optional[GarmentItem]:
     """
     Select the best garment from *pool* for the given type, formality chain,
-    and optional size preference.
+    size preference, and colour preference.
 
     Selection priority (per formality tier, in chain order):
       For each tier:
-        1. Unused, size-matched, event-appropriate
+        1. Unused, size-matched, colour-scored, event-appropriate
         2. Unused, event-appropriate (no size match required)
-        3. Already-used, size-matched, event-appropriate
+        3. Already-used, size-matched, colour-scored, event-appropriate
         4. Already-used, event-appropriate
       After exhausting all explicit tiers:
         5. Garments with formality=None (untagged) — treated as last resort
@@ -244,6 +330,11 @@ def _pick_garment(
            never silently dropped.
       Final fallback:
         6. None — no appropriate garment found
+
+    Colour scoring (via :func:`_score_color_preference`) applies a penalty for
+    avoided colours and a bonus for favourite colours or matching colour tone.
+    Items with a negative colour score are deprioritised relative to
+    colour-neutral or colour-positive items within the same tier.
     """
     candidates = [
         g for g in pool
@@ -252,29 +343,38 @@ def _pick_garment(
     if not candidates:
         return None
 
-    # Sort by times_recommended ascending to promote variety across generations.
-    candidates.sort(key=lambda g: g.times_recommended)
+    # Primary sort: times_recommended ascending (variety); tiebreak: colour score descending.
+    candidates.sort(
+        key=lambda g: (g.times_recommended, -_score_color_preference(g, user_profile))
+    )
 
     def formality_matches(g: GarmentItem, tier: frozenset[str]) -> bool:
         return g.formality is not None and g.formality.value in tier
 
     def _pick_from(subset: list[GarmentItem]) -> Optional[GarmentItem]:
-        """Return the best item from *subset* applying size preference."""
+        """Return the best item from *subset* applying size and colour preference."""
         if not subset:
             return None
         unused = [g for g in subset if g.id not in used_ids]
         in_use = [g for g in subset if g.id in used_ids]
-        if user_size_label:
-            unused_sized = [g for g in unused if _size_matches(g, user_size_label)]
-            if unused_sized:
-                return unused_sized[0]
-        if unused:
-            return unused[0]
-        if user_size_label:
-            used_sized = [g for g in in_use if _size_matches(g, user_size_label)]
-            if used_sized:
-                return used_sized[0]
-        return in_use[0] if in_use else None
+
+        # Within unused: prefer items with a non-negative colour score.
+        def _best(items: list[GarmentItem]) -> Optional[GarmentItem]:
+            if not items:
+                return None
+            # Filter out strongly-avoided items if alternatives exist.
+            not_avoided = [g for g in items if _score_color_preference(g, user_profile) >= 0]
+            pool = not_avoided if not_avoided else items
+            if user_size_label:
+                sized = [g for g in pool if _size_matches(g, user_size_label)]
+                if sized:
+                    return sized[0]
+            return pool[0]
+
+        result = _best(unused)
+        if result is not None:
+            return result
+        return _best(in_use)
 
     for tier in formality_chain:
         tier_candidates = [g for g in candidates if formality_matches(g, tier)]
@@ -309,6 +409,7 @@ async def generate_week_recommendations(
     events: list[WeekEvent],
     user_gender: Optional[str] = None,
     measurements: Optional[BodyMeasurements] = None,
+    user_profile: Optional[UserProfile] = None,
 ) -> list[DayOutfitSuggestion]:
     """
     Generate one :class:`DayOutfitSuggestion` per event in *events*.
@@ -317,12 +418,14 @@ async def generate_week_recommendations(
     LLM (with garment images forwarded when available).
 
     Args:
-        wardrobe:     All garments belonging to the user. May be empty.
-        events:       The user's week plan. Each entry describes one day.
-        user_gender:  Optional gender string (``"male"``, ``"female"``, ``"other"``).
-                      When set, garments tagged for the opposite binary gender are
-                      excluded before selection begins.
-        measurements: Optional body measurements used for soft size-band scoring.
+        wardrobe:      All garments belonging to the user. May be empty.
+        events:        The user's week plan. Each entry describes one day.
+        user_gender:   Optional gender string (``"male"``, ``"female"``, ``"other"``).
+                       When set, garments tagged for the opposite binary gender are
+                       excluded before selection begins.
+        measurements:  Optional body measurements used for soft size-band scoring.
+        user_profile:  Optional extended style profile used for colour preference
+                       scoring (favourite/avoided colours and colour tone).
 
     Returns:
         A list of :class:`DayOutfitSuggestion` objects in the same order as
@@ -364,11 +467,13 @@ async def generate_week_recommendations(
             wardrobe, _is_top, formality_chain, used_ids,
             event_type=event.event_type,
             user_size_label=user_size_label,
+            user_profile=user_profile,
         )
         bottom = _pick_garment(
             wardrobe, _is_bottom, formality_chain, used_ids,
             event_type=event.event_type,
             user_size_label=user_size_label,
+            user_profile=user_profile,
         )
 
         # If top or bottom is missing, try a dress as a fallback
@@ -378,6 +483,7 @@ async def generate_week_recommendations(
                 wardrobe, _is_dress, formality_chain, used_ids,
                 event_type=event.event_type,
                 user_size_label=user_size_label,
+                user_profile=user_profile,
             )
 
         if dress is not None and (top is None or bottom is None):

--- a/backend/recommendation.py
+++ b/backend/recommendation.py
@@ -207,6 +207,48 @@ def _color_words(color_str: Optional[str]) -> frozenset[str]:
     return frozenset(re.split(r"[\s,/\-_]+", color_str.strip().lower()))
 
 
+class _ColorPrefCtx:
+    """
+    Pre-computed colour preference data for a single ``_pick_garment`` call.
+
+    Building ``avoid_words`` / ``fav_words`` once per call (rather than once
+    per garment comparison) eliminates the O(n × |preferences|) rebuild cost
+    that would otherwise occur for larger wardrobes.
+    """
+
+    __slots__ = ("avoid_words", "fav_words", "tone")
+
+    def __init__(self, profile: Optional[UserProfile]) -> None:
+        if profile is None:
+            self.avoid_words: frozenset[str] = frozenset()
+            self.fav_words: frozenset[str] = frozenset()
+            self.tone: Optional[str] = None
+        else:
+            self.avoid_words = frozenset(
+                w for c in (profile.avoided_colors or []) for w in _color_words(c)
+            )
+            self.fav_words = frozenset(
+                w for c in (profile.favorite_colors or []) for w in _color_words(c)
+            )
+            self.tone = profile.color_tone.lower() if profile.color_tone else None
+
+    def score(self, item: GarmentItem) -> float:
+        """Return the colour preference score for *item* using precomputed token sets."""
+        item_words = _color_words(item.color_primary) | _color_words(item.color_secondary)
+        if not item_words:
+            return 0.0
+        sc = 0.0
+        if self.avoid_words and item_words & self.avoid_words:
+            sc += _COLOR_AVOID_PENALTY
+        if self.fav_words and item_words & self.fav_words:
+            sc += _COLOR_MATCH_BONUS
+        if self.tone == "warm" and item_words & _WARM_COLOR_FAMILIES:
+            sc += _COLOR_TONE_BONUS
+        elif self.tone == "cool" and item_words & _COOL_COLOR_FAMILIES:
+            sc += _COLOR_TONE_BONUS
+        return sc
+
+
 def _score_color_preference(item: GarmentItem, profile: Optional[UserProfile]) -> float:
     """
     Return a floating-point colour score for *item* given *profile*.
@@ -215,44 +257,12 @@ def _score_color_preference(item: GarmentItem, profile: Optional[UserProfile]) -
     indicate colours the user explicitly wants to avoid.  Returns 0.0 when
     no profile is provided or preferences are empty.
 
-    The score is additive and relative — it does not replace formality or
-    size scoring, but is factored in when selecting among otherwise-equal
-    candidates.
+    .. note::
+        This public helper re-creates token sets on every call.  Inside
+        ``_pick_garment`` use :class:`_ColorPrefCtx` instead so token sets
+        are computed only once per request.
     """
-    if profile is None:
-        return 0.0
-
-    item_words = _color_words(item.color_primary) | _color_words(item.color_secondary)
-    if not item_words:
-        return 0.0
-
-    score = 0.0
-
-    # Hard penalty for avoided colours — any word overlap triggers it.
-    if profile.avoided_colors:
-        avoid_words = frozenset(
-            w for c in profile.avoided_colors for w in _color_words(c)
-        )
-        if item_words & avoid_words:
-            score += _COLOR_AVOID_PENALTY
-
-    # Bonus for explicitly preferred colours.
-    if profile.favorite_colors:
-        fav_words = frozenset(
-            w for c in profile.favorite_colors for w in _color_words(c)
-        )
-        if item_words & fav_words:
-            score += _COLOR_MATCH_BONUS
-
-    # Soft bonus / mild penalty for colour tone alignment.
-    if profile.color_tone:
-        tone = profile.color_tone.lower()
-        if tone == "warm" and item_words & _WARM_COLOR_FAMILIES:
-            score += _COLOR_TONE_BONUS
-        elif tone == "cool" and item_words & _COOL_COLOR_FAMILIES:
-            score += _COLOR_TONE_BONUS
-
-    return score
+    return _ColorPrefCtx(profile).score(item)
 
 
 # ---------------------------------------------------------------------------
@@ -320,21 +330,20 @@ def _pick_garment(
 
     Selection priority (per formality tier, in chain order):
       For each tier:
-        1. Unused, size-matched, colour-scored, event-appropriate
-        2. Unused, event-appropriate (no size match required)
-        3. Already-used, size-matched, colour-scored, event-appropriate
-        4. Already-used, event-appropriate
+        1. Unused, size-matched, not-avoided, event-appropriate   ← best
+        2. Unused, size-matched, any colour                       ← size always beats colour
+        3. Unused, not-avoided (no size match)
+        4. Unused, any colour (last unused resort)
+        5. Same four levels repeated for already-used items
       After exhausting all explicit tiers:
-        5. Garments with formality=None (untagged) — treated as last resort
-           so existing vision-ingested items without a formality value are
-           never silently dropped.
+        6. Garments with formality=None (untagged) — treated as last resort.
       Final fallback:
-        6. None — no appropriate garment found
+        7. None — no appropriate garment found
 
-    Colour scoring (via :func:`_score_color_preference`) applies a penalty for
-    avoided colours and a bonus for favourite colours or matching colour tone.
-    Items with a negative colour score are deprioritised relative to
-    colour-neutral or colour-positive items within the same tier.
+    Colour scoring is computed once per call via :class:`_ColorPrefCtx` to
+    avoid rebuilding token sets for every garment comparison.  Size matching
+    always takes priority over colour avoidance — a correctly-sized
+    avoided-colour item is preferred over a not-avoided item that doesn't fit.
     """
     candidates = [
         g for g in pool
@@ -343,34 +352,52 @@ def _pick_garment(
     if not candidates:
         return None
 
-    # Primary sort: times_recommended ascending (variety); tiebreak: colour score descending.
-    candidates.sort(
-        key=lambda g: (g.times_recommended, -_score_color_preference(g, user_profile))
-    )
+    # Build colour preference context once for this call.
+    ctx = _ColorPrefCtx(user_profile)
+
+    # Cache per-garment scores so the lambda in sort() and _best() each only
+    # compute the score once.
+    color_scores: dict[str, float] = {g.id: ctx.score(g) for g in candidates}
+
+    # Primary sort: variety (times_recommended asc); tiebreak: colour score desc.
+    candidates.sort(key=lambda g: (g.times_recommended, -color_scores[g.id]))
 
     def formality_matches(g: GarmentItem, tier: frozenset[str]) -> bool:
         return g.formality is not None and g.formality.value in tier
 
+    def _best(items: list[GarmentItem]) -> Optional[GarmentItem]:
+        """
+        Return the best item from *items* respecting the size-first,
+        colour-second priority order.
+        """
+        if not items:
+            return None
+
+        if user_size_label:
+            # 1st priority: size-matched AND not-avoided
+            sized_clean = [
+                g for g in items
+                if _size_matches(g, user_size_label) and color_scores[g.id] >= 0
+            ]
+            if sized_clean:
+                return sized_clean[0]
+            # 2nd priority: size-matched (even if avoided colour)
+            sized_any = [g for g in items if _size_matches(g, user_size_label)]
+            if sized_any:
+                return sized_any[0]
+
+        # No size preference or no size-matched item: prefer not-avoided colour.
+        not_avoided = [g for g in items if color_scores[g.id] >= 0]
+        if not_avoided:
+            return not_avoided[0]
+        return items[0]
+
     def _pick_from(subset: list[GarmentItem]) -> Optional[GarmentItem]:
-        """Return the best item from *subset* applying size and colour preference."""
+        """Split *subset* into unused / in-use and pick from each in order."""
         if not subset:
             return None
         unused = [g for g in subset if g.id not in used_ids]
         in_use = [g for g in subset if g.id in used_ids]
-
-        # Within unused: prefer items with a non-negative colour score.
-        def _best(items: list[GarmentItem]) -> Optional[GarmentItem]:
-            if not items:
-                return None
-            # Filter out strongly-avoided items if alternatives exist.
-            not_avoided = [g for g in items if _score_color_preference(g, user_profile) >= 0]
-            pool = not_avoided if not_avoided else items
-            if user_size_label:
-                sized = [g for g in pool if _size_matches(g, user_size_label)]
-                if sized:
-                    return sized[0]
-            return pool[0]
-
         result = _best(unused)
         if result is not None:
             return result
@@ -383,8 +410,8 @@ def _pick_garment(
             return result
 
     # Fallback: items whose formality was never set (e.g. vision-ingested with
-    # no recognized formality label).  These are treated as context-neutral
-    # rather than excluded outright.
+    # no recognized formality label).  Treated as context-neutral rather than
+    # excluded outright.
     untagged = [g for g in candidates if g.formality is None]
     return _pick_from(untagged)
 

--- a/backend/routers/profile_router.py
+++ b/backend/routers/profile_router.py
@@ -28,7 +28,6 @@ class AvatarConfigBody(BaseModel):
     hair_color: Optional[str] = None
     body_type: Optional[str] = None
     skin_tone: Optional[str] = None
-    avatar_image_url: Optional[str] = None
 
 
 class UserProfileBody(BaseModel):
@@ -108,7 +107,6 @@ async def update_profile(user_id: str, body: UserProfileBody) -> UserProfile:
                 hair_color=av.hair_color,
                 body_type=av.body_type,
                 skin_tone=av.skin_tone,
-                avatar_image_url=av.avatar_image_url,
             )
 
     return upsert_user_profile(user_id, data)

--- a/backend/routers/profile_router.py
+++ b/backend/routers/profile_router.py
@@ -1,0 +1,100 @@
+"""
+routers/profile_router.py — User style-profile endpoints.
+
+GET  /users/{user_id}/profile  — fetch the user's extended profile.
+PUT  /users/{user_id}/profile  — create or partially update the profile.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..db import get_user_profile, upsert_user_profile
+from ..models import AvatarConfig, UserProfile
+
+router = APIRouter(prefix="/users", tags=["profile"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response bodies
+# ---------------------------------------------------------------------------
+
+
+class AvatarConfigBody(BaseModel):
+    hair_style: Optional[str] = None
+    hair_color: Optional[str] = None
+    body_type: Optional[str] = None
+    skin_tone: Optional[str] = None
+
+
+class UserProfileBody(BaseModel):
+    """
+    Partial update body for ``PUT /users/{user_id}/profile``.
+
+    All fields are optional so that callers can update any subset without
+    knowing the full current state.
+    """
+
+    gender: Optional[str] = None
+    birthday: Optional[str] = None
+    skin_tone: Optional[str] = None
+    color_tone: Optional[str] = None
+    favorite_colors: Optional[List[str]] = None
+    avoided_colors: Optional[List[str]] = None
+    shoe_size: Optional[str] = None
+    top_size: Optional[str] = None
+    bottom_size: Optional[str] = None
+    avatar_config: Optional[AvatarConfigBody] = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{user_id}/profile", response_model=UserProfile)
+async def get_profile(user_id: str) -> UserProfile:
+    """
+    Return the extended style profile for *user_id*.
+
+    Returns ``404`` when the profile has never been saved (e.g. users who
+    signed up before this feature was deployed).
+    """
+    profile = get_user_profile(user_id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+
+@router.put("/{user_id}/profile", response_model=UserProfile)
+async def update_profile(user_id: str, body: UserProfileBody) -> UserProfile:
+    """
+    Create or partially update the extended style profile for *user_id*.
+
+    Only explicitly provided (non-``null``) fields are written; omitted fields
+    are not touched on existing profiles.
+    """
+    data: dict[str, Any] = {}
+
+    for field in ("gender", "birthday", "skin_tone", "color_tone", "shoe_size", "top_size", "bottom_size"):
+        value = getattr(body, field)
+        if value is not None:
+            data[field] = value
+
+    if body.favorite_colors is not None:
+        data["favorite_colors"] = body.favorite_colors
+    if body.avoided_colors is not None:
+        data["avoided_colors"] = body.avoided_colors
+
+    if body.avatar_config is not None:
+        data["avatar_config"] = AvatarConfig(
+            hair_style=body.avatar_config.hair_style,
+            hair_color=body.avatar_config.hair_color,
+            body_type=body.avatar_config.body_type,
+            skin_tone=body.avatar_config.skin_tone,
+        )
+
+    return upsert_user_profile(user_id, data)

--- a/backend/routers/profile_router.py
+++ b/backend/routers/profile_router.py
@@ -28,6 +28,7 @@ class AvatarConfigBody(BaseModel):
     hair_color: Optional[str] = None
     body_type: Optional[str] = None
     skin_tone: Optional[str] = None
+    avatar_image_url: Optional[str] = None
 
 
 class UserProfileBody(BaseModel):
@@ -36,6 +37,11 @@ class UserProfileBody(BaseModel):
 
     All fields are optional so that callers can update any subset without
     knowing the full current state.
+
+    **Omitted vs explicit null**:  Pydantic records which fields were actually
+    supplied in the request via ``model_fields_set``.  The endpoint uses this
+    to distinguish "caller didn't mention the field" (leave unchanged) from
+    "caller explicitly sent ``null``" (clear the stored value).
     """
 
     gender: Optional[str] = None
@@ -74,27 +80,35 @@ async def update_profile(user_id: str, body: UserProfileBody) -> UserProfile:
     """
     Create or partially update the extended style profile for *user_id*.
 
-    Only explicitly provided (non-``null``) fields are written; omitted fields
-    are not touched on existing profiles.
+    Only fields **present in the request body** are written.  Omitted fields
+    are left unchanged on existing profiles.  Explicitly sending ``null``
+    clears the stored value (e.g. ``{"skin_tone": null}`` removes the tone
+    preference).
     """
     data: dict[str, Any] = {}
 
-    for field in ("gender", "birthday", "skin_tone", "color_tone", "shoe_size", "top_size", "bottom_size"):
-        value = getattr(body, field)
-        if value is not None:
-            data[field] = value
+    # Scalar / list fields — write only when the caller explicitly provided them
+    # (whether the value is a string, a list, or null).
+    for field in (
+        "gender", "birthday", "skin_tone", "color_tone",
+        "shoe_size", "top_size", "bottom_size",
+        "favorite_colors", "avoided_colors",
+    ):
+        if field in body.model_fields_set:
+            data[field] = getattr(body, field)
 
-    if body.favorite_colors is not None:
-        data["favorite_colors"] = body.favorite_colors
-    if body.avoided_colors is not None:
-        data["avoided_colors"] = body.avoided_colors
-
-    if body.avatar_config is not None:
-        data["avatar_config"] = AvatarConfig(
-            hair_style=body.avatar_config.hair_style,
-            hair_color=body.avatar_config.hair_color,
-            body_type=body.avatar_config.body_type,
-            skin_tone=body.avatar_config.skin_tone,
-        )
+    # avatar_config: null clears it; an object merges individual sub-fields.
+    if "avatar_config" in body.model_fields_set:
+        if body.avatar_config is None:
+            data["avatar_config"] = None
+        else:
+            av = body.avatar_config
+            data["avatar_config"] = AvatarConfig(
+                hair_style=av.hair_style,
+                hair_color=av.hair_color,
+                body_type=av.body_type,
+                skin_tone=av.skin_tone,
+                avatar_image_url=av.avatar_image_url,
+            )
 
     return upsert_user_profile(user_id, data)

--- a/backend/routers/recommendations.py
+++ b/backend/routers/recommendations.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from ..db import get_measurements, increment_recommendation_counts
+from ..db import get_measurements, get_user_profile, increment_recommendation_counts
 from ..models import (
     DayOutfitSuggestion,
     WeekRecommendationRequest,
@@ -72,6 +72,9 @@ async def recommend_week(
     # Load optional body measurements for soft size-band scoring.
     measurements = get_measurements(request.user_id)
 
+    # Load optional extended profile for colour preference scoring.
+    user_profile = get_user_profile(request.user_id)
+
     # Future: fetch weather per event and pass WeatherContext into the engine.
     # for event in request.events:
     #     if event.location and event.datetime:
@@ -85,6 +88,7 @@ async def recommend_week(
         request.events,
         user_gender=request.user_gender,
         measurements=measurements,
+        user_profile=user_profile,
     )
 
     # Increment usage counters for recommended garments (best-effort).

--- a/backend/tests/test_integration/test_profile_routes.py
+++ b/backend/tests/test_integration/test_profile_routes.py
@@ -5,7 +5,7 @@ Covers:
 - PUT /users/{user_id}/profile → creates a new profile
 - PUT (partial) → updates without clobbering omitted fields
 - PUT with explicit null → clears a stored field
-- avatar_config round-trip (including avatar_image_url)
+- avatar_config round-trip
 """
 
 from __future__ import annotations
@@ -116,14 +116,6 @@ class TestPutProfile:
         assert cfg["hair_style"] == "long_straight"
         assert cfg["hair_color"] == "black"
         assert cfg["skin_tone"] == "medium_dark"
-
-    async def test_avatar_image_url_persisted(self, client):
-        r = await client.put(
-            "/users/u1/profile",
-            json={"avatar_config": {"avatar_image_url": "https://example.com/avatar.jpg"}},
-        )
-        assert r.status_code == 200
-        assert r.json()["avatar_config"]["avatar_image_url"] == "https://example.com/avatar.jpg"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_integration/test_profile_routes.py
+++ b/backend/tests/test_integration/test_profile_routes.py
@@ -1,0 +1,159 @@
+"""Integration tests for the user profile endpoints.
+
+Covers:
+- GET /users/{user_id}/profile → 404 when profile has never been saved
+- PUT /users/{user_id}/profile → creates a new profile
+- PUT (partial) → updates without clobbering omitted fields
+- PUT with explicit null → clears a stored field
+- avatar_config round-trip (including avatar_image_url)
+"""
+
+from __future__ import annotations
+
+import pytest
+import httpx
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from backend.routers import profile_router
+from backend.db import _local_user_profiles
+
+
+@pytest.fixture(autouse=True)
+def _clear_profiles():
+    _local_user_profiles.clear()
+    yield
+    _local_user_profiles.clear()
+
+
+@pytest.fixture()
+def app() -> FastAPI:
+    a = FastAPI()
+    a.include_router(profile_router.router)
+    return a
+
+
+@pytest.fixture()
+async def client(app, _isolate_env):
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET — missing profile
+# ---------------------------------------------------------------------------
+
+
+class TestGetProfile:
+    async def test_404_when_profile_not_found(self, client):
+        r = await client.get("/users/nobody/profile")
+        assert r.status_code == 404
+        assert "not found" in r.json()["detail"].lower()
+
+    async def test_200_after_upsert(self, client):
+        await client.put("/users/u1/profile", json={"gender": "female"})
+        r = await client.get("/users/u1/profile")
+        assert r.status_code == 200
+        assert r.json()["gender"] == "female"
+
+
+# ---------------------------------------------------------------------------
+# PUT — create and partial update
+# ---------------------------------------------------------------------------
+
+
+class TestPutProfile:
+    async def test_create_returns_full_profile(self, client):
+        r = await client.put(
+            "/users/u1/profile",
+            json={
+                "gender": "male",
+                "skin_tone": "medium",
+                "favorite_colors": ["blue", "navy"],
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["gender"] == "male"
+        assert data["skin_tone"] == "medium"
+        assert data["favorite_colors"] == ["blue", "navy"]
+
+    async def test_partial_update_does_not_clobber_omitted_fields(self, client):
+        # Seed full profile
+        await client.put(
+            "/users/u1/profile",
+            json={"gender": "female", "color_tone": "warm", "shoe_size": "38"},
+        )
+        # Partial update — only update shoe_size
+        r = await client.put("/users/u1/profile", json={"shoe_size": "39"})
+        assert r.status_code == 200
+        data = r.json()
+        # Omitted fields must remain unchanged
+        assert data["gender"] == "female"
+        assert data["color_tone"] == "warm"
+        assert data["shoe_size"] == "39"
+
+    async def test_idempotent_put(self, client):
+        await client.put("/users/u1/profile", json={"gender": "other"})
+        r = await client.put("/users/u1/profile", json={"gender": "other"})
+        assert r.status_code == 200
+
+    async def test_avatar_config_round_trip(self, client):
+        r = await client.put(
+            "/users/u1/profile",
+            json={
+                "avatar_config": {
+                    "hair_style": "long_straight",
+                    "hair_color": "black",
+                    "body_type": "slim",
+                    "skin_tone": "medium_dark",
+                }
+            },
+        )
+        assert r.status_code == 200
+        cfg = r.json()["avatar_config"]
+        assert cfg["hair_style"] == "long_straight"
+        assert cfg["hair_color"] == "black"
+        assert cfg["skin_tone"] == "medium_dark"
+
+    async def test_avatar_image_url_persisted(self, client):
+        r = await client.put(
+            "/users/u1/profile",
+            json={"avatar_config": {"avatar_image_url": "https://example.com/avatar.jpg"}},
+        )
+        assert r.status_code == 200
+        assert r.json()["avatar_config"]["avatar_image_url"] == "https://example.com/avatar.jpg"
+
+
+# ---------------------------------------------------------------------------
+# PUT with explicit null → clears stored values
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitNullClears:
+    async def test_null_clears_scalar_field(self, client):
+        await client.put("/users/u1/profile", json={"shoe_size": "42"})
+
+        r = await client.put("/users/u1/profile", json={"shoe_size": None})
+        assert r.status_code == 200
+        assert r.json()["shoe_size"] is None
+
+    async def test_null_clears_avatar_config(self, client):
+        await client.put(
+            "/users/u1/profile",
+            json={"avatar_config": {"hair_style": "short_wavy"}},
+        )
+        r = await client.put("/users/u1/profile", json={"avatar_config": None})
+        assert r.status_code == 200
+        assert r.json()["avatar_config"] is None
+
+    async def test_null_clears_list_field(self, client):
+        await client.put(
+            "/users/u1/profile",
+            json={"favorite_colors": ["red", "orange"]},
+        )
+        r = await client.put("/users/u1/profile", json={"favorite_colors": None})
+        assert r.status_code == 200
+        # Cleared list — stored as empty by the local store helper
+        assert r.json()["favorite_colors"] in (None, [])

--- a/backend/tests/test_unit/test_db.py
+++ b/backend/tests/test_unit/test_db.py
@@ -9,19 +9,24 @@ import pytest
 from backend.db import (
     _local_wardrobes,
     _local_signup_user_ids,
+    _local_user_profiles,
     _parse_category,
     _parse_datetime,
     _parse_formality,
     _parse_rpc_scalar_int,
     _parse_seasonality,
     _row_to_garment,
+    _row_to_user_profile,
     _use_local_store,
     count_registered_signups,
+    get_user_profile,
     get_wardrobe,
     insert_garment,
     register_signup_user_id,
+    upsert_user_profile,
 )
 from backend.models import (
+    AvatarConfig,
     GarmentCategory,
     GarmentFormality,
     GarmentItem,
@@ -36,9 +41,11 @@ _NOW = datetime(2026, 4, 14, 12, 0, 0, tzinfo=timezone.utc)
 def _clear_local_stores():
     _local_wardrobes.clear()
     _local_signup_user_ids.clear()
+    _local_user_profiles.clear()
     yield
     _local_wardrobes.clear()
     _local_signup_user_ids.clear()
+    _local_user_profiles.clear()
 
 
 class TestUseLocalStore:
@@ -229,3 +236,110 @@ class TestSignupRegistry:
     def test_overlong_ignored(self):
         register_signup_user_id("x" * 600)
         assert count_registered_signups() == 0
+
+
+# ---------------------------------------------------------------------------
+# User profile helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRowToUserProfile:
+    def test_minimal_row(self):
+        row = {"user_id": "u1", "updated_at": "2026-04-14T12:00:00Z"}
+        p = _row_to_user_profile(row)
+        assert p.user_id == "u1"
+        assert p.avatar_config is None
+        assert p.favorite_colors == []
+        assert p.avoided_colors == []
+
+    def test_avatar_config_dict_parsed(self):
+        row = {
+            "user_id": "u1",
+            "avatar_config": {
+                "hair_style": "long_straight",
+                "hair_color": "black",
+                "body_type": "slim",
+                "skin_tone": "medium",
+                "avatar_image_url": "https://example.com/avatar.jpg",
+            },
+        }
+        p = _row_to_user_profile(row)
+        assert p.avatar_config is not None
+        assert p.avatar_config.hair_style == "long_straight"
+        assert p.avatar_config.skin_tone == "medium"
+        assert p.avatar_config.avatar_image_url == "https://example.com/avatar.jpg"
+
+    def test_avatar_config_none_stays_none(self):
+        row = {"user_id": "u1", "avatar_config": None}
+        p = _row_to_user_profile(row)
+        assert p.avatar_config is None
+
+    def test_avatar_config_string_ignored(self):
+        # Non-dict values (e.g., corrupt data) should not crash.
+        row = {"user_id": "u1", "avatar_config": "invalid"}
+        p = _row_to_user_profile(row)
+        assert p.avatar_config is None
+
+    def test_color_lists_parsed(self):
+        row = {
+            "user_id": "u1",
+            "favorite_colors": ["navy", "white"],
+            "avoided_colors": ["red"],
+        }
+        p = _row_to_user_profile(row)
+        assert p.favorite_colors == ["navy", "white"]
+        assert p.avoided_colors == ["red"]
+
+
+class TestLocalStoreUserProfile:
+    @pytest.fixture(autouse=True)
+    def _ensure_local(self, monkeypatch):
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+
+    def test_get_returns_none_when_missing(self):
+        assert get_user_profile("nobody") is None
+
+    def test_upsert_creates_new_profile(self):
+        p = upsert_user_profile("u1", {"gender": "female", "skin_tone": "light"})
+        assert p.user_id == "u1"
+        assert p.gender == "female"
+        assert p.skin_tone == "light"
+
+    def test_upsert_partial_does_not_clobber(self):
+        upsert_user_profile("u1", {"gender": "female", "shoe_size": "38"})
+        upsert_user_profile("u1", {"shoe_size": "39"})
+        p = get_user_profile("u1")
+        assert p is not None
+        assert p.gender == "female"
+        assert p.shoe_size == "39"
+
+    def test_explicit_none_clears_field(self):
+        upsert_user_profile("u1", {"skin_tone": "medium"})
+        upsert_user_profile("u1", {"skin_tone": None})
+        p = get_user_profile("u1")
+        assert p is not None
+        assert p.skin_tone is None
+
+    def test_avatar_config_model_serialised_and_round_tripped(self):
+        cfg = AvatarConfig(
+            hair_style="curly_afro",
+            hair_color="auburn",
+            body_type="average",
+            skin_tone="dark",
+            avatar_image_url="https://example.com/av.jpg",
+        )
+        upsert_user_profile("u1", {"avatar_config": cfg})
+        p = get_user_profile("u1")
+        assert p is not None
+        assert p.avatar_config is not None
+        assert p.avatar_config.hair_style == "curly_afro"
+        assert p.avatar_config.avatar_image_url == "https://example.com/av.jpg"
+
+    def test_avatar_config_none_clears(self):
+        cfg = AvatarConfig(hair_style="short_wavy")
+        upsert_user_profile("u1", {"avatar_config": cfg})
+        upsert_user_profile("u1", {"avatar_config": None})
+        p = get_user_profile("u1")
+        assert p is not None
+        assert p.avatar_config is None

--- a/backend/tests/test_unit/test_db.py
+++ b/backend/tests/test_unit/test_db.py
@@ -260,14 +260,12 @@ class TestRowToUserProfile:
                 "hair_color": "black",
                 "body_type": "slim",
                 "skin_tone": "medium",
-                "avatar_image_url": "https://example.com/avatar.jpg",
             },
         }
         p = _row_to_user_profile(row)
         assert p.avatar_config is not None
         assert p.avatar_config.hair_style == "long_straight"
         assert p.avatar_config.skin_tone == "medium"
-        assert p.avatar_config.avatar_image_url == "https://example.com/avatar.jpg"
 
     def test_avatar_config_none_stays_none(self):
         row = {"user_id": "u1", "avatar_config": None}
@@ -327,14 +325,13 @@ class TestLocalStoreUserProfile:
             hair_color="auburn",
             body_type="average",
             skin_tone="dark",
-            avatar_image_url="https://example.com/av.jpg",
         )
         upsert_user_profile("u1", {"avatar_config": cfg})
         p = get_user_profile("u1")
         assert p is not None
         assert p.avatar_config is not None
         assert p.avatar_config.hair_style == "curly_afro"
-        assert p.avatar_config.avatar_image_url == "https://example.com/av.jpg"
+        assert p.avatar_config.skin_tone == "dark"
 
     def test_avatar_config_none_clears(self):
         cfg = AvatarConfig(hair_style="short_wavy")

--- a/backend/tests/test_unit/test_recommendation.py
+++ b/backend/tests/test_unit/test_recommendation.py
@@ -8,15 +8,58 @@ from backend.models import (
     GarmentCategory,
     GarmentFormality,
     GarmentItem,
+    UserProfile,
     WeekEvent,
+    build_garment_tags,
 )
 from backend.recommendation import (
+    _ColorPrefCtx,
     _display_name,
     _is_bottom,
     _is_top,
     _pick_garment,
+    _score_color_preference,
     generate_week_recommendations,
 )
+from datetime import datetime, timezone
+
+_NOW = datetime(2026, 4, 14, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_top(
+    id: str,
+    color: str | None,
+    formality: GarmentFormality = GarmentFormality.CASUAL,
+    size: str | None = None,
+) -> GarmentItem:
+    tags = build_garment_tags(GarmentCategory.TOP, formality)
+    return GarmentItem(
+        id=id,
+        user_id="u1",
+        primary_image_url="https://x.com/img.jpg",
+        category=GarmentCategory.TOP,
+        sub_category="shirt",
+        formality=formality,
+        color_primary=color,
+        size=size,
+        tags=tags,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+def _profile(
+    favorite_colors: list[str] | None = None,
+    avoided_colors: list[str] | None = None,
+    color_tone: str | None = None,
+) -> UserProfile:
+    return UserProfile(
+        user_id="u1",
+        favorite_colors=favorite_colors or [],
+        avoided_colors=avoided_colors or [],
+        color_tone=color_tone,
+        updated_at=_NOW,
+    )
 
 
 # -- helpers -----------------------------------------------------------------
@@ -141,3 +184,123 @@ class TestGenerateWeekRecommendations:
             top = next((g for g in mock_wardrobe if g.id == rec.top_id), None)
             assert top is not None
             assert top.formality in (GarmentFormality.FORMAL, GarmentFormality.BUSINESS)
+
+
+# -- Colour preference scoring ----------------------------------------------
+
+
+class TestColorPrefCtx:
+    def test_no_profile_zero_score(self):
+        ctx = _ColorPrefCtx(None)
+        item = _make_top("t1", "red")
+        assert ctx.score(item) == 0.0
+
+    def test_avoided_color_penalty(self):
+        ctx = _ColorPrefCtx(_profile(avoided_colors=["red"]))
+        item = _make_top("t1", "red")
+        assert ctx.score(item) < 0
+
+    def test_favorite_color_bonus(self):
+        ctx = _ColorPrefCtx(_profile(favorite_colors=["navy"]))
+        item = _make_top("t1", "navy")
+        assert ctx.score(item) > 0
+
+    def test_warm_tone_bonus(self):
+        ctx = _ColorPrefCtx(_profile(color_tone="warm"))
+        item = _make_top("t1", "rust")
+        assert ctx.score(item) > 0
+
+    def test_cool_tone_bonus(self):
+        ctx = _ColorPrefCtx(_profile(color_tone="cool"))
+        item = _make_top("t1", "teal")
+        assert ctx.score(item) > 0
+
+    def test_no_color_on_item_zero_score(self):
+        ctx = _ColorPrefCtx(_profile(favorite_colors=["blue"]))
+        item = _make_top("t1", None)
+        assert ctx.score(item) == 0.0
+
+    def test_score_color_preference_public_helper(self):
+        p = _profile(avoided_colors=["yellow"])
+        item = _make_top("t1", "yellow")
+        assert _score_color_preference(item, p) < 0
+
+
+class TestPickGarmentColourPriority:
+    """Verify the size-first, colour-second selection order."""
+
+    def test_avoided_colours_deprioritised_when_alternative_exists(self):
+        avoided = _make_top("avoided", "red", GarmentFormality.CASUAL)
+        clean = _make_top("clean", "navy", GarmentFormality.CASUAL)
+        profile = _profile(avoided_colors=["red"])
+        result = _pick_garment(
+            [avoided, clean],
+            _is_top,
+            [frozenset({"casual"})],
+            used_ids=set(),
+            user_profile=profile,
+        )
+        assert result is not None
+        assert result.id == "clean"
+
+    def test_avoided_item_returned_when_it_is_only_option(self):
+        avoided = _make_top("avoided", "red", GarmentFormality.CASUAL)
+        profile = _profile(avoided_colors=["red"])
+        result = _pick_garment(
+            [avoided],
+            _is_top,
+            [frozenset({"casual"})],
+            used_ids=set(),
+            user_profile=profile,
+        )
+        assert result is not None
+        assert result.id == "avoided"
+
+    def test_favourite_colour_preferred_as_tiebreak(self):
+        # Both items same formality, same times_recommended; fav colour wins.
+        plain = _make_top("plain", "grey", GarmentFormality.CASUAL)
+        fav = _make_top("fav", "navy", GarmentFormality.CASUAL)
+        profile = _profile(favorite_colors=["navy"])
+        result = _pick_garment(
+            [plain, fav],
+            _is_top,
+            [frozenset({"casual"})],
+            used_ids=set(),
+            user_profile=profile,
+        )
+        assert result is not None
+        assert result.id == "fav"
+
+    def test_sized_item_beats_avoided_colour_unsized(self):
+        """Size match trumps colour preference — a sized avoided item is preferred
+        over a not-avoided item that doesn't match the user's size."""
+        sized_avoided = _make_top("sized_avoided", "red", GarmentFormality.CASUAL, size="m")
+        unsized_clean = _make_top("unsized_clean", "navy", GarmentFormality.CASUAL, size=None)
+        profile = _profile(avoided_colors=["red"])
+        result = _pick_garment(
+            [sized_avoided, unsized_clean],
+            _is_top,
+            [frozenset({"casual"})],
+            used_ids=set(),
+            user_size_label="m",
+            user_profile=profile,
+        )
+        # The sized item should win even though its colour is avoided.
+        assert result is not None
+        assert result.id == "sized_avoided"
+
+    def test_sized_clean_beats_sized_avoided(self):
+        """When there is a sized AND not-avoided option, it should win."""
+        sized_avoided = _make_top("sized_avoided", "red", GarmentFormality.CASUAL, size="m")
+        sized_clean = _make_top("sized_clean", "navy", GarmentFormality.CASUAL, size="m")
+        profile = _profile(avoided_colors=["red"])
+        result = _pick_garment(
+            [sized_avoided, sized_clean],
+            _is_top,
+            [frozenset({"casual"})],
+            used_ids=set(),
+            user_size_label="m",
+            user_profile=profile,
+        )
+        assert result is not None
+        assert result.id == "sized_clean"

--- a/misfitai-mobile/App.tsx
+++ b/misfitai-mobile/App.tsx
@@ -6,10 +6,11 @@ import { AppStateProvider, useAppState } from './src/AppStateContext';
 import { WardrobeScreen } from './src/WardrobeScreen';
 import { EventsScreen } from './src/EventsScreen';
 import { WeeklyPlanScreen } from './src/WeeklyPlanScreen';
-import { registerSignupWithBackend, USE_MOCK_API } from './src/api';
+import { ProfileScreen } from './src/ProfileScreen';
+import { registerSignupWithBackend, updateUserProfile, USE_MOCK_API } from './src/api';
 import { AtmosphereBackground } from './src/AtmosphereBackground';
 import { AuthScreen, type AuthMode, type AuthProvider, type UserProfile } from './src/AuthScreen';
-import { ProfileSetupScreen } from './src/ProfileSetupScreen';
+import { ProfileSetupScreen, type ProfileSetupResult } from './src/ProfileSetupScreen';
 import { palette, radius, type } from './src/theme';
 import { initAnalytics, trackAuthSuccess } from './src/analytics';
 
@@ -38,7 +39,7 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
 
 const SESSION_STORAGE_KEY = '@misfitai/session';
 
-type Tab = 'wardrobe' | 'events' | 'plan';
+type Tab = 'wardrobe' | 'events' | 'plan' | 'profile';
 
 type Session = {
   provider: AuthProvider;
@@ -81,7 +82,8 @@ function ProfileSetupScreenWithMeasurements({
   return (
     <ProfileSetupScreen
       initialProfile={session.profile}
-      onDone={(profilePatch, measurements) => {
+      onDone={(result: ProfileSetupResult) => {
+        const { profilePatch, measurements, profileUpdate } = result;
         const next: Session = {
           ...session,
           profile: { ...(session.profile ?? {}), ...profilePatch },
@@ -95,6 +97,10 @@ function ProfileSetupScreenWithMeasurements({
             /* non-blocking */
           });
         }
+        // Save extended profile data (color preferences, sizes, avatar) non-blocking.
+        updateUserProfile(next.userId, profileUpdate).catch(() => {
+          /* non-blocking */
+        });
       }}
     />
   );
@@ -133,6 +139,10 @@ function AppContent({
 
   const handleTabChange = (nextTab: Tab) => {
     setTab(nextTab);
+    if (nextTab === 'profile') {
+      setTabHint(null);
+      return;
+    }
     if (nextTab === 'events' && !wardrobeStepComplete) {
       setTabHint('Wardrobe is complete after at least one top and one bottom.');
       return;
@@ -153,7 +163,7 @@ function AppContent({
       <StatusBar style="dark" />
       <AtmosphereBackground />
 
-      <View style={styles.topChrome}>
+      <View style={[styles.topChrome, tab === 'profile' && styles.topChromeCompact]}>
         <View style={styles.metaBar}>
           <View style={styles.metaChip}>
             <Text style={styles.metaChipText}>
@@ -167,7 +177,7 @@ function AppContent({
           </Pressable>
         </View>
 
-        <View style={styles.stepperCard}>
+        {tab !== 'profile' ? <View style={styles.stepperCard}>
           {flowSteps.map((item, index) => {
             const active = tab === item.key;
             return (
@@ -196,9 +206,9 @@ function AppContent({
               </React.Fragment>
             );
           })}
-        </View>
+        </View> : null}
 
-        <View style={styles.breadcrumbRow}>
+        {tab !== 'profile' ? <View style={styles.breadcrumbRow}>
           {flowSteps.map((item, index) => {
             const active = tab === item.key;
             return (
@@ -218,9 +228,9 @@ function AppContent({
               </React.Fragment>
             );
           })}
-        </View>
+        </View> : null}
 
-        {tabHint ? <Text style={styles.stepHint}>{tabHint}</Text> : null}
+        {tab !== 'profile' && tabHint ? <Text style={styles.stepHint}>{tabHint}</Text> : null}
       </View>
 
       <View style={styles.content}>
@@ -254,6 +264,13 @@ function AppContent({
             onNavigateToWardrobe={() => handleTabChange('wardrobe')}
           />
         ) : null}
+
+        {tab === 'profile' ? (
+          <ProfileScreen
+            userId={session.userId}
+            displayName={session.profile?.displayName}
+          />
+        ) : null}
       </View>
 
       <View style={styles.navBar}>
@@ -261,6 +278,7 @@ function AppContent({
           { key: 'wardrobe', label: 'Wardrobe' },
           { key: 'events', label: 'Calendar' },
           { key: 'plan', label: 'Outfits' },
+          { key: 'profile', label: 'Profile' },
         ] as const).map((item) => {
           const active = tab === item.key;
           return (
@@ -396,6 +414,9 @@ const styles = StyleSheet.create({
     paddingTop: 50,
     paddingHorizontal: 14,
     gap: 8,
+  },
+  topChromeCompact: {
+    gap: 0,
   },
   content: {
     flex: 1,

--- a/misfitai-mobile/App.tsx
+++ b/misfitai-mobile/App.tsx
@@ -7,7 +7,7 @@ import { WardrobeScreen } from './src/WardrobeScreen';
 import { EventsScreen } from './src/EventsScreen';
 import { WeeklyPlanScreen } from './src/WeeklyPlanScreen';
 import { ProfileScreen } from './src/ProfileScreen';
-import { registerSignupWithBackend, updateUserProfile, USE_MOCK_API } from './src/api';
+import { generateAvatar, registerSignupWithBackend, updateUserProfile, USE_MOCK_API } from './src/api';
 import { AtmosphereBackground } from './src/AtmosphereBackground';
 import { AuthScreen, type AuthMode, type AuthProvider, type UserProfile } from './src/AuthScreen';
 import { ProfileSetupScreen, type ProfileSetupResult } from './src/ProfileSetupScreen';
@@ -83,7 +83,7 @@ function ProfileSetupScreenWithMeasurements({
     <ProfileSetupScreen
       initialProfile={session.profile}
       onDone={(result: ProfileSetupResult) => {
-        const { profilePatch, measurements, profileUpdate } = result;
+        const { profilePatch, measurements, profileUpdate, selfieUri } = result;
         const next: Session = {
           ...session,
           profile: { ...(session.profile ?? {}), ...profilePatch },
@@ -98,9 +98,16 @@ function ProfileSetupScreenWithMeasurements({
           });
         }
         // Save extended profile data (color preferences, sizes, avatar) non-blocking.
-        updateUserProfile(next.userId, profileUpdate).catch(() => {
-          /* non-blocking */
-        });
+        // If a selfie was provided, chain avatar generation after the profile is saved.
+        updateUserProfile(next.userId, profileUpdate)
+          .then(() => {
+            if (selfieUri) {
+              return generateAvatar(next.userId, selfieUri);
+            }
+          })
+          .catch(() => {
+            /* non-blocking — avatar generation failure should not block onboarding */
+          });
       }}
     />
   );

--- a/misfitai-mobile/App.tsx
+++ b/misfitai-mobile/App.tsx
@@ -7,7 +7,7 @@ import { WardrobeScreen } from './src/WardrobeScreen';
 import { EventsScreen } from './src/EventsScreen';
 import { WeeklyPlanScreen } from './src/WeeklyPlanScreen';
 import { ProfileScreen } from './src/ProfileScreen';
-import { generateAvatar, registerSignupWithBackend, updateUserProfile, USE_MOCK_API } from './src/api';
+import { registerSignupWithBackend, updateUserProfile, USE_MOCK_API } from './src/api';
 import { AtmosphereBackground } from './src/AtmosphereBackground';
 import { AuthScreen, type AuthMode, type AuthProvider, type UserProfile } from './src/AuthScreen';
 import { ProfileSetupScreen, type ProfileSetupResult } from './src/ProfileSetupScreen';
@@ -83,7 +83,7 @@ function ProfileSetupScreenWithMeasurements({
     <ProfileSetupScreen
       initialProfile={session.profile}
       onDone={(result: ProfileSetupResult) => {
-        const { profilePatch, measurements, profileUpdate, selfieUri } = result;
+        const { profilePatch, measurements, profileUpdate } = result;
         const next: Session = {
           ...session,
           profile: { ...(session.profile ?? {}), ...profilePatch },
@@ -98,16 +98,9 @@ function ProfileSetupScreenWithMeasurements({
           });
         }
         // Save extended profile data (color preferences, sizes, avatar) non-blocking.
-        // If a selfie was provided, chain avatar generation after the profile is saved.
-        updateUserProfile(next.userId, profileUpdate)
-          .then(() => {
-            if (selfieUri) {
-              return generateAvatar(next.userId, selfieUri);
-            }
-          })
-          .catch(() => {
-            /* non-blocking — avatar generation failure should not block onboarding */
-          });
+        updateUserProfile(next.userId, profileUpdate).catch(() => {
+          /* non-blocking */
+        });
       }}
     />
   );

--- a/misfitai-mobile/src/ProfileScreen.tsx
+++ b/misfitai-mobile/src/ProfileScreen.tsx
@@ -254,7 +254,7 @@ function AvatarEditModal({
   onSave: (v: AvatarEditState) => void;
 }) {
   const [draft, setDraft] = useState<AvatarEditState>(initial);
-  useEffect(() => { setDraft(initial); }, [visible]);
+  useEffect(() => { setDraft(initial); }, [visible, initial]);
 
   return (
     <Modal visible={visible} animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
@@ -413,6 +413,9 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
       });
       setProfile(updated);
       setPersonalDirty(false);
+    } catch {
+      Alert.alert('Save failed', 'Could not save personal info. Please try again.');
+      // Keep dirty=true so the save bar remains visible.
     } finally {
       setPersonalSaving(false);
     }
@@ -431,6 +434,8 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
       };
       await updateMeasurements(data);
       setBodyDirty(false);
+    } catch {
+      Alert.alert('Save failed', 'Could not save measurements. Please try again.');
     } finally {
       setBodySaving(false);
     }
@@ -447,6 +452,8 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
       });
       setProfile(updated);
       setStyleDirty(false);
+    } catch {
+      Alert.alert('Save failed', 'Could not save style preferences. Please try again.');
     } finally {
       setStyleSaving(false);
     }
@@ -462,6 +469,8 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
       });
       setProfile(updated);
       setSizesDirty(false);
+    } catch {
+      Alert.alert('Save failed', 'Could not save sizes. Please try again.');
     } finally {
       setSizesSaving(false);
     }

--- a/misfitai-mobile/src/ProfileScreen.tsx
+++ b/misfitai-mobile/src/ProfileScreen.tsx
@@ -1,0 +1,979 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { AtmosphereBackground } from './AtmosphereBackground';
+import { palette, radius, type } from './theme';
+import { useAppState } from './AppStateContext';
+import {
+  getUserProfile,
+  updateUserProfile,
+} from './api';
+import type {
+  AvatarConfig,
+  BodyMeasurements,
+  ColorTone,
+  SkinTone,
+  UserProfile,
+  UserProfileUpdate,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Constants (shared with wizard — colour data, sizes, avatar options)
+// ---------------------------------------------------------------------------
+
+const SKIN_TONES: { key: SkinTone; label: string; hex: string }[] = [
+  { key: 'very_light', label: 'Very Light', hex: '#FDDBB4' },
+  { key: 'light', label: 'Light', hex: '#F5C5A3' },
+  { key: 'medium_light', label: 'Medium Light', hex: '#D4956A' },
+  { key: 'medium', label: 'Medium', hex: '#B46A3C' },
+  { key: 'medium_dark', label: 'Medium Dark', hex: '#8D4A24' },
+  { key: 'dark', label: 'Dark', hex: '#4A2515' },
+];
+
+const COLOR_TONE_OPTIONS: { key: ColorTone; label: string }[] = [
+  { key: 'warm', label: 'Warm' },
+  { key: 'cool', label: 'Cool' },
+  { key: 'neutral', label: 'Neutral' },
+];
+
+const PALETTE_COLORS = [
+  { key: 'black', label: 'Black', hex: '#111111' },
+  { key: 'white', label: 'White', hex: '#F5F5F0' },
+  { key: 'grey', label: 'Grey', hex: '#9E9E9E' },
+  { key: 'navy', label: 'Navy', hex: '#1A2E5C' },
+  { key: 'blue', label: 'Blue', hex: '#2979FF' },
+  { key: 'green', label: 'Green', hex: '#2E7D32' },
+  { key: 'olive', label: 'Olive', hex: '#6D6E32' },
+  { key: 'brown', label: 'Brown', hex: '#795548' },
+  { key: 'beige', label: 'Beige', hex: '#D4B896' },
+  { key: 'red', label: 'Red', hex: '#C62828' },
+  { key: 'pink', label: 'Pink', hex: '#E91E8C' },
+  { key: 'yellow', label: 'Yellow', hex: '#F9A825' },
+];
+
+const SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
+
+const HAIR_STYLES = [
+  { key: 'short_straight', label: 'Short Straight' },
+  { key: 'short_wavy', label: 'Short Wavy' },
+  { key: 'long_straight', label: 'Long Straight' },
+  { key: 'long_wavy', label: 'Long Wavy' },
+  { key: 'curly_afro', label: 'Curly / Afro' },
+  { key: 'bald', label: 'Bald / Shaved' },
+];
+
+const HAIR_COLORS = [
+  { key: 'black', label: 'Black' },
+  { key: 'dark_brown', label: 'Dark Brown' },
+  { key: 'light_brown', label: 'Light Brown' },
+  { key: 'auburn', label: 'Auburn' },
+  { key: 'blonde', label: 'Blonde' },
+  { key: 'red', label: 'Red' },
+  { key: 'grey', label: 'Grey' },
+  { key: 'white', label: 'White' },
+];
+
+const BODY_TYPES = [
+  { key: 'slim', label: 'Slim / Athletic' },
+  { key: 'average', label: 'Average' },
+  { key: 'broad', label: 'Broad / Plus' },
+];
+
+// ---------------------------------------------------------------------------
+// Small shared UI helpers
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ title, onEdit }: { title: string; onEdit?: () => void }) {
+  return (
+    <View style={s.sectionHeader}>
+      <Text style={s.sectionTitle}>{title}</Text>
+      {onEdit ? (
+        <Pressable onPress={onEdit} hitSlop={8}>
+          <Text style={s.editLink}>Edit</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function FieldRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={s.fieldRow}>
+      <Text style={s.fieldLabel}>{label}</Text>
+      <Text style={s.fieldValue}>{value || '—'}</Text>
+    </View>
+  );
+}
+
+function ChipRow<T extends string>({
+  options,
+  value,
+  onSelect,
+}: {
+  options: { key: T; label: string }[];
+  value: T | null | undefined;
+  onSelect: (v: T | null) => void;
+}) {
+  return (
+    <View style={s.chipRow}>
+      {options.map((opt) => {
+        const active = value === opt.key;
+        return (
+          <Pressable
+            key={opt.key}
+            onPress={() => onSelect(active ? null : opt.key)}
+            style={[s.chip, active && s.chipActive]}
+          >
+            <Text style={[s.chipText, active && s.chipTextActive]}>{opt.label}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function ColorSwatchGrid({
+  colors,
+  selected,
+  onToggle,
+}: {
+  colors: { key: string; label: string; hex: string }[];
+  selected: string[];
+  onToggle: (key: string) => void;
+}) {
+  return (
+    <View style={s.swatchGrid}>
+      {colors.map((c) => {
+        const active = selected.includes(c.key);
+        return (
+          <Pressable key={c.key} onPress={() => onToggle(c.key)} style={s.swatchItem}>
+            <View
+              style={[
+                s.swatch,
+                { backgroundColor: c.hex },
+                active && s.swatchActive,
+              ]}
+            />
+            <Text style={[s.swatchLabel, active && s.swatchLabelActive]}>{c.label}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function SaveBar({
+  dirty,
+  saving,
+  onSave,
+  onDiscard,
+}: {
+  dirty: boolean;
+  saving: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+}) {
+  if (!dirty && !saving) return null;
+  return (
+    <View style={s.saveBar}>
+      <Pressable onPress={onDiscard} style={[s.btn, s.btnGhost]}>
+        <Text style={[s.btnText, s.btnGhostText]}>Discard</Text>
+      </Pressable>
+      <Pressable onPress={onSave} style={[s.btn, s.btnPrimary]} disabled={saving}>
+        {saving ? (
+          <ActivityIndicator color={palette.panelStrong} size="small" />
+        ) : (
+          <Text style={[s.btnText, s.btnPrimaryText]}>Save</Text>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Avatar preview + edit modal
+// ---------------------------------------------------------------------------
+
+function AvatarPreview({
+  avatar,
+  skinTone,
+}: {
+  avatar: AvatarConfig | null | undefined;
+  skinTone: SkinTone | null | undefined;
+}) {
+  const hex =
+    SKIN_TONES.find((t) => t.key === (avatar?.skinTone ?? skinTone))?.hex ?? '#D4956A';
+
+  return (
+    <View style={s.avatarPreview}>
+      {/* Simple silhouette placeholder — replace with actual illustration assets */}
+      <View style={[s.avatarCircle, { backgroundColor: hex }]}>
+        <Text style={s.avatarInitial}>👤</Text>
+      </View>
+      <View style={s.avatarDetails}>
+        <Text style={s.avatarLine}>
+          {avatar?.bodyType ? avatar.bodyType.replace('_', ' ') : 'Body type: —'}
+        </Text>
+        <Text style={s.avatarLine}>
+          {avatar?.hairStyle ? avatar.hairStyle.replace(/_/g, ' ') : 'Hair: —'}
+        </Text>
+        <Text style={s.avatarLine}>
+          {avatar?.hairColor ? avatar.hairColor.replace(/_/g, ' ') : 'Hair colour: —'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+interface AvatarEditState {
+  hairStyle: string | null;
+  hairColor: string | null;
+  bodyType: string | null;
+  skinTone: SkinTone | null;
+}
+
+function AvatarEditModal({
+  visible,
+  initial,
+  onClose,
+  onSave,
+}: {
+  visible: boolean;
+  initial: AvatarEditState;
+  onClose: () => void;
+  onSave: (v: AvatarEditState) => void;
+}) {
+  const [draft, setDraft] = useState<AvatarEditState>(initial);
+  useEffect(() => { setDraft(initial); }, [visible]);
+
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
+      <SafeAreaView style={s.modalSafe}>
+        <View style={s.modalHeader}>
+          <Text style={s.modalTitle}>Edit Avatar</Text>
+          <Pressable onPress={onClose} hitSlop={12}>
+            <Text style={s.modalClose}>✕</Text>
+          </Pressable>
+        </View>
+        <ScrollView contentContainerStyle={s.modalBody} keyboardShouldPersistTaps="handled">
+          <Text style={s.label}>Skin Tone</Text>
+          <View style={s.swatchGrid}>
+            {SKIN_TONES.map((st) => {
+              const active = draft.skinTone === st.key;
+              return (
+                <Pressable
+                  key={st.key}
+                  onPress={() => setDraft((d) => ({ ...d, skinTone: active ? null : st.key }))}
+                  style={s.swatchItem}
+                >
+                  <View style={[s.swatch, { backgroundColor: st.hex }, active && s.swatchActive]} />
+                  <Text style={[s.swatchLabel, active && s.swatchLabelActive]}>{st.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={[s.label, { marginTop: 16 }]}>Hair Style</Text>
+          <ChipRow
+            options={HAIR_STYLES}
+            value={draft.hairStyle as string | null}
+            onSelect={(v) => setDraft((d) => ({ ...d, hairStyle: v }))}
+          />
+
+          <Text style={[s.label, { marginTop: 16 }]}>Hair Colour</Text>
+          <ChipRow
+            options={HAIR_COLORS}
+            value={draft.hairColor as string | null}
+            onSelect={(v) => setDraft((d) => ({ ...d, hairColor: v }))}
+          />
+
+          <Text style={[s.label, { marginTop: 16 }]}>Body Type</Text>
+          <ChipRow
+            options={BODY_TYPES}
+            value={draft.bodyType as string | null}
+            onSelect={(v) => setDraft((d) => ({ ...d, bodyType: v }))}
+          />
+        </ScrollView>
+        <View style={s.modalFooter}>
+          <Pressable onPress={onClose} style={[s.btn, s.btnGhost]}>
+            <Text style={[s.btnText, s.btnGhostText]}>Cancel</Text>
+          </Pressable>
+          <Pressable onPress={() => { onSave(draft); onClose(); }} style={[s.btn, s.btnPrimary]}>
+            <Text style={[s.btnText, s.btnPrimaryText]}>Apply</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main ProfileScreen
+// ---------------------------------------------------------------------------
+
+function parsePositiveFloat(value: string): number | null {
+  const v = value.trim();
+  if (!v) return null;
+  const n = parseFloat(v);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function ProfileScreen({ userId, displayName }: { userId: string; displayName?: string | null }) {
+  const { measurements, updateMeasurements } = useAppState();
+
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // --- Personal section ---
+  const [gender, setGender] = useState<'male' | 'female' | 'other' | null>(null);
+  const [birthday, setBirthday] = useState('');
+  const [personalDirty, setPersonalDirty] = useState(false);
+  const [personalSaving, setPersonalSaving] = useState(false);
+
+  // --- Body measurements ---
+  const [heightCm, setHeightCm] = useState('');
+  const [weightKg, setWeightKg] = useState('');
+  const [chestCm, setChestCm] = useState('');
+  const [waistCm, setWaistCm] = useState('');
+  const [hipsCm, setHipsCm] = useState('');
+  const [inseamCm, setInseamCm] = useState('');
+  const [bodyDirty, setBodyDirty] = useState(false);
+  const [bodySaving, setBodySaving] = useState(false);
+
+  // --- Style preferences ---
+  const [skinTone, setSkinTone] = useState<SkinTone | null>(null);
+  const [colorTone, setColorTone] = useState<ColorTone | null>(null);
+  const [favoriteColors, setFavoriteColors] = useState<string[]>([]);
+  const [avoidedColors, setAvoidedColors] = useState<string[]>([]);
+  const [styleDirty, setStyleDirty] = useState(false);
+  const [styleSaving, setStyleSaving] = useState(false);
+
+  // --- Sizes ---
+  const [topSize, setTopSize] = useState<string | null>(null);
+  const [bottomSize, setBottomSize] = useState<string | null>(null);
+  const [shoeSize, setShoeSize] = useState('');
+  const [sizesDirty, setSizesDirty] = useState(false);
+  const [sizesSaving, setSizesSaving] = useState(false);
+
+  // --- Avatar ---
+  const [avatar, setAvatar] = useState<AvatarConfig | null>(null);
+  const [avatarModalOpen, setAvatarModalOpen] = useState(false);
+
+  // --- Load ---
+  useEffect(() => {
+    setLoading(true);
+    getUserProfile(userId)
+      .then((p) => {
+        if (p) {
+          setProfile(p);
+          setGender(p.gender ?? null);
+          setBirthday(p.birthday ?? '');
+          setSkinTone(p.skinTone ?? null);
+          setColorTone(p.colorTone ?? null);
+          setFavoriteColors(p.favoriteColors ?? []);
+          setAvoidedColors(p.avoidedColors ?? []);
+          setTopSize(p.topSize ?? null);
+          setBottomSize(p.bottomSize ?? null);
+          setShoeSize(p.shoeSize ?? '');
+          setAvatar(p.avatarConfig ?? null);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  useEffect(() => {
+    if (measurements) {
+      setHeightCm(measurements.heightCm != null ? String(measurements.heightCm) : '');
+      setWeightKg(measurements.weightKg != null ? String(measurements.weightKg) : '');
+      setChestCm(measurements.chestCm != null ? String(measurements.chestCm) : '');
+      setWaistCm(measurements.waistCm != null ? String(measurements.waistCm) : '');
+      setHipsCm(measurements.hipsCm != null ? String(measurements.hipsCm) : '');
+      setInseamCm(measurements.inseamCm != null ? String(measurements.inseamCm) : '');
+    }
+  }, [measurements]);
+
+  // --- Save helpers ---
+
+  const savePersonal = useCallback(async () => {
+    setPersonalSaving(true);
+    try {
+      const updated = await updateUserProfile(userId, {
+        gender: gender ?? null,
+        birthday: birthday.trim() || null,
+      });
+      setProfile(updated);
+      setPersonalDirty(false);
+    } finally {
+      setPersonalSaving(false);
+    }
+  }, [userId, gender, birthday]);
+
+  const saveBody = useCallback(async () => {
+    setBodySaving(true);
+    try {
+      const data: Omit<BodyMeasurements, 'userId' | 'updatedAt'> = {
+        heightCm: parsePositiveFloat(heightCm),
+        weightKg: parsePositiveFloat(weightKg),
+        chestCm: parsePositiveFloat(chestCm),
+        waistCm: parsePositiveFloat(waistCm),
+        hipsCm: parsePositiveFloat(hipsCm),
+        inseamCm: parsePositiveFloat(inseamCm),
+      };
+      await updateMeasurements(data);
+      setBodyDirty(false);
+    } finally {
+      setBodySaving(false);
+    }
+  }, [userId, heightCm, weightKg, chestCm, waistCm, hipsCm, inseamCm, updateMeasurements]);
+
+  const saveStyle = useCallback(async () => {
+    setStyleSaving(true);
+    try {
+      const updated = await updateUserProfile(userId, {
+        skinTone,
+        colorTone,
+        favoriteColors,
+        avoidedColors,
+      });
+      setProfile(updated);
+      setStyleDirty(false);
+    } finally {
+      setStyleSaving(false);
+    }
+  }, [userId, skinTone, colorTone, favoriteColors, avoidedColors]);
+
+  const saveSizes = useCallback(async () => {
+    setSizesSaving(true);
+    try {
+      const updated = await updateUserProfile(userId, {
+        topSize: topSize ?? null,
+        bottomSize: bottomSize ?? null,
+        shoeSize: shoeSize.trim() || null,
+      });
+      setProfile(updated);
+      setSizesDirty(false);
+    } finally {
+      setSizesSaving(false);
+    }
+  }, [userId, topSize, bottomSize, shoeSize]);
+
+  const saveAvatar = useCallback(async (newAvatar: AvatarConfig) => {
+    setAvatar(newAvatar);
+    try {
+      const updated = await updateUserProfile(userId, { avatarConfig: newAvatar });
+      setProfile(updated);
+    } catch {
+      /* non-blocking */
+    }
+  }, [userId]);
+
+  // --- Discard helpers ---
+  const discardPersonal = () => {
+    setGender(profile?.gender ?? null);
+    setBirthday(profile?.birthday ?? '');
+    setPersonalDirty(false);
+  };
+  const discardBody = () => {
+    if (measurements) {
+      setHeightCm(measurements.heightCm != null ? String(measurements.heightCm) : '');
+      setWeightKg(measurements.weightKg != null ? String(measurements.weightKg) : '');
+      setChestCm(measurements.chestCm != null ? String(measurements.chestCm) : '');
+      setWaistCm(measurements.waistCm != null ? String(measurements.waistCm) : '');
+      setHipsCm(measurements.hipsCm != null ? String(measurements.hipsCm) : '');
+      setInseamCm(measurements.inseamCm != null ? String(measurements.inseamCm) : '');
+    }
+    setBodyDirty(false);
+  };
+  const discardStyle = () => {
+    setSkinTone(profile?.skinTone ?? null);
+    setColorTone(profile?.colorTone ?? null);
+    setFavoriteColors(profile?.favoriteColors ?? []);
+    setAvoidedColors(profile?.avoidedColors ?? []);
+    setStyleDirty(false);
+  };
+  const discardSizes = () => {
+    setTopSize(profile?.topSize ?? null);
+    setBottomSize(profile?.bottomSize ?? null);
+    setShoeSize(profile?.shoeSize ?? '');
+    setSizesDirty(false);
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={s.safe}>
+        <AtmosphereBackground />
+        <View style={s.center}>
+          <ActivityIndicator color={palette.accent} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={s.safe}>
+      <AtmosphereBackground />
+      <ScrollView contentContainerStyle={s.container} keyboardShouldPersistTaps="handled">
+        <Text style={s.screenTitle}>My Profile</Text>
+
+        {/* ---- Personal ---- */}
+        <SectionHeader title="Personal" />
+        <View style={s.card}>
+          {displayName ? <FieldRow label="Name" value={displayName} /> : null}
+
+          <Text style={s.label}>Gender</Text>
+          <ChipRow
+            options={[
+              { key: 'female', label: 'Female' },
+              { key: 'male', label: 'Male' },
+              { key: 'other', label: 'Other' },
+            ]}
+            value={gender}
+            onSelect={(v) => { setGender(v as typeof gender); setPersonalDirty(true); }}
+          />
+
+          <Text style={[s.label, { marginTop: 14 }]}>Birthday</Text>
+          <TextInput
+            value={birthday}
+            onChangeText={(v) => { setBirthday(v); setPersonalDirty(true); }}
+            placeholder="YYYY-MM-DD (optional)"
+            placeholderTextColor={palette.muted}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType={Platform.OS === 'web' ? 'default' : 'numbers-and-punctuation'}
+            style={s.input}
+          />
+        </View>
+        <SaveBar dirty={personalDirty} saving={personalSaving} onSave={savePersonal} onDiscard={discardPersonal} />
+
+        {/* ---- Body measurements ---- */}
+        <SectionHeader title="Body Measurements" />
+        <View style={s.card}>
+          <Text style={s.hint}>All in centimetres / kilograms. Used to suggest better-fitting items.</Text>
+          {(
+            [
+              { label: 'Height (cm)', value: heightCm, setter: setHeightCm },
+              { label: 'Weight (kg)', value: weightKg, setter: setWeightKg },
+              { label: 'Chest / Bust (cm)', value: chestCm, setter: setChestCm },
+              { label: 'Waist (cm)', value: waistCm, setter: setWaistCm },
+              { label: 'Hips (cm)', value: hipsCm, setter: setHipsCm },
+              { label: 'Inseam (cm)', value: inseamCm, setter: setInseamCm },
+            ] as const
+          ).map(({ label, value, setter }) => (
+            <View key={label} style={s.measureRow}>
+              <Text style={s.measureLabel}>{label}</Text>
+              <TextInput
+                value={value}
+                onChangeText={(v) => { setter(v); setBodyDirty(true); }}
+                placeholder="—"
+                placeholderTextColor={palette.muted}
+                keyboardType="decimal-pad"
+                style={s.measureInput}
+              />
+            </View>
+          ))}
+        </View>
+        <SaveBar dirty={bodyDirty} saving={bodySaving} onSave={saveBody} onDiscard={discardBody} />
+
+        {/* ---- Style preferences ---- */}
+        <SectionHeader title="Style Preferences" />
+        <View style={s.card}>
+          <Text style={s.label}>Skin Tone</Text>
+          <View style={s.swatchGrid}>
+            {SKIN_TONES.map((st) => {
+              const active = skinTone === st.key;
+              return (
+                <Pressable
+                  key={st.key}
+                  onPress={() => { setSkinTone(active ? null : st.key); setStyleDirty(true); }}
+                  style={s.swatchItem}
+                >
+                  <View style={[s.swatch, { backgroundColor: st.hex }, active && s.swatchActive]} />
+                  <Text style={[s.swatchLabel, active && s.swatchLabelActive]}>{st.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={[s.label, { marginTop: 16 }]}>Colour Tone</Text>
+          <ChipRow
+            options={COLOR_TONE_OPTIONS}
+            value={colorTone}
+            onSelect={(v) => { setColorTone(v as ColorTone | null); setStyleDirty(true); }}
+          />
+
+          <Text style={[s.label, { marginTop: 16 }]}>Favourite Colours</Text>
+          <ColorSwatchGrid
+            colors={PALETTE_COLORS}
+            selected={favoriteColors}
+            onToggle={(key) => {
+              const next = favoriteColors.includes(key)
+                ? favoriteColors.filter((c) => c !== key)
+                : [...favoriteColors, key];
+              setFavoriteColors(next);
+              setStyleDirty(true);
+            }}
+          />
+
+          <Text style={[s.label, { marginTop: 16 }]}>Colours to Avoid</Text>
+          <ColorSwatchGrid
+            colors={PALETTE_COLORS}
+            selected={avoidedColors}
+            onToggle={(key) => {
+              const next = avoidedColors.includes(key)
+                ? avoidedColors.filter((c) => c !== key)
+                : [...avoidedColors, key];
+              setAvoidedColors(next);
+              setStyleDirty(true);
+            }}
+          />
+        </View>
+        <SaveBar dirty={styleDirty} saving={styleSaving} onSave={saveStyle} onDiscard={discardStyle} />
+
+        {/* ---- Sizes ---- */}
+        <SectionHeader title="Sizes" />
+        <View style={s.card}>
+          <Text style={s.label}>Top Size</Text>
+          <ChipRow
+            options={SIZE_OPTIONS.map((sz) => ({ key: sz, label: sz }))}
+            value={topSize}
+            onSelect={(v) => { setTopSize(v); setSizesDirty(true); }}
+          />
+
+          <Text style={[s.label, { marginTop: 14 }]}>Bottom Size</Text>
+          <ChipRow
+            options={SIZE_OPTIONS.map((sz) => ({ key: sz, label: sz }))}
+            value={bottomSize}
+            onSelect={(v) => { setBottomSize(v); setSizesDirty(true); }}
+          />
+
+          <Text style={[s.label, { marginTop: 14 }]}>Shoe Size (EU / US)</Text>
+          <TextInput
+            value={shoeSize}
+            onChangeText={(v) => { setShoeSize(v); setSizesDirty(true); }}
+            placeholder="e.g. 42 or 9"
+            placeholderTextColor={palette.muted}
+            keyboardType="decimal-pad"
+            style={s.input}
+          />
+        </View>
+        <SaveBar dirty={sizesDirty} saving={sizesSaving} onSave={saveSizes} onDiscard={discardSizes} />
+
+        {/* ---- Avatar ---- */}
+        <SectionHeader title="Avatar" />
+        <View style={s.card}>
+          <AvatarPreview avatar={avatar} skinTone={skinTone} />
+          <Pressable onPress={() => setAvatarModalOpen(true)} style={[s.btn, s.btnOutline, { marginTop: 14 }]}>
+            <Text style={[s.btnText, s.btnOutlineText]}>Edit Avatar</Text>
+          </Pressable>
+        </View>
+
+        <View style={{ height: 40 }} />
+      </ScrollView>
+
+      <AvatarEditModal
+        visible={avatarModalOpen}
+        initial={{
+          hairStyle: avatar?.hairStyle ?? null,
+          hairColor: avatar?.hairColor ?? null,
+          bodyType: avatar?.bodyType ?? null,
+          skinTone: (avatar?.skinTone ?? skinTone) as SkinTone | null,
+        }}
+        onClose={() => setAvatarModalOpen(false)}
+        onSave={(draft) => {
+          const newAvatar: AvatarConfig = {
+            hairStyle: draft.hairStyle,
+            hairColor: draft.hairColor,
+            bodyType: draft.bodyType,
+            skinTone: draft.skinTone,
+          };
+          void saveAvatar(newAvatar);
+        }}
+      />
+    </SafeAreaView>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const s = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: palette.bg },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  container: {
+    paddingHorizontal: 18,
+    paddingTop: 20,
+    paddingBottom: 40,
+  },
+  screenTitle: {
+    fontSize: 26,
+    color: palette.ink,
+    fontFamily: type.title,
+    marginBottom: 20,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 18,
+    marginBottom: 6,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    letterSpacing: 0.7,
+    textTransform: 'uppercase',
+    color: palette.muted,
+    fontFamily: type.bodyDemi,
+  },
+  editLink: {
+    fontSize: 13,
+    color: palette.accent,
+    fontFamily: type.bodyDemi,
+  },
+  card: {
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panel,
+    padding: 16,
+    marginBottom: 4,
+  },
+  fieldRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: palette.line,
+  },
+  fieldLabel: {
+    fontSize: 13,
+    color: palette.muted,
+    fontFamily: type.body,
+  },
+  fieldValue: {
+    fontSize: 13,
+    color: palette.ink,
+    fontFamily: type.bodyMedium,
+  },
+  label: {
+    fontSize: 12,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: palette.muted,
+    fontFamily: type.bodyDemi,
+    marginBottom: 8,
+  },
+  hint: {
+    fontSize: 12,
+    color: palette.muted,
+    fontFamily: type.body,
+    lineHeight: 18,
+    marginBottom: 12,
+  },
+  input: {
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: palette.ink,
+    fontFamily: type.body,
+  },
+  measureRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: palette.line,
+  },
+  measureLabel: {
+    fontSize: 13,
+    color: palette.inkSoft,
+    fontFamily: type.body,
+    flex: 1,
+  },
+  measureInput: {
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    fontSize: 13,
+    color: palette.ink,
+    fontFamily: type.body,
+    width: 90,
+    textAlign: 'right',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  chipActive: {
+    backgroundColor: palette.accent,
+    borderColor: palette.accent,
+  },
+  chipText: {
+    fontSize: 13,
+    color: palette.inkSoft,
+    fontFamily: type.bodyMedium,
+  },
+  chipTextActive: {
+    color: palette.panelStrong,
+  },
+  swatchGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    marginTop: 4,
+  },
+  swatchItem: {
+    alignItems: 'center',
+    width: 52,
+  },
+  swatch: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  swatchActive: {
+    borderColor: palette.accent,
+  },
+  swatchLabel: {
+    fontSize: 10,
+    color: palette.muted,
+    fontFamily: type.body,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  swatchLabelActive: {
+    color: palette.ink,
+    fontFamily: type.bodyDemi,
+  },
+  saveBar: {
+    flexDirection: 'row',
+    gap: 10,
+    marginBottom: 6,
+    marginTop: 2,
+  },
+  btn: {
+    flex: 1,
+    borderRadius: radius.md,
+    paddingVertical: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  btnGhost: {
+    backgroundColor: 'transparent',
+    borderColor: palette.lineStrong,
+  },
+  btnPrimary: {
+    backgroundColor: palette.accent,
+    borderColor: palette.accent,
+  },
+  btnOutline: {
+    backgroundColor: 'transparent',
+    borderColor: palette.accent,
+    flex: 0,
+    paddingHorizontal: 20,
+  },
+  btnText: {
+    fontSize: 13,
+    fontFamily: type.bodyDemi,
+  },
+  btnGhostText: {
+    color: palette.inkSoft,
+  },
+  btnPrimaryText: {
+    color: palette.panelStrong,
+  },
+  btnOutlineText: {
+    color: palette.accent,
+  },
+  avatarPreview: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  avatarCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarInitial: {
+    fontSize: 32,
+  },
+  avatarDetails: {
+    flex: 1,
+    gap: 4,
+  },
+  avatarLine: {
+    fontSize: 13,
+    color: palette.inkSoft,
+    fontFamily: type.body,
+    textTransform: 'capitalize',
+  },
+  // Modal
+  modalSafe: {
+    flex: 1,
+    backgroundColor: palette.bg,
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: palette.line,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontFamily: type.title,
+    color: palette.ink,
+  },
+  modalClose: {
+    fontSize: 18,
+    color: palette.muted,
+    fontFamily: type.body,
+  },
+  modalBody: {
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  modalFooter: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderTopWidth: 1,
+    borderTopColor: palette.line,
+  },
+});

--- a/misfitai-mobile/src/ProfileSetupScreen.tsx
+++ b/misfitai-mobile/src/ProfileSetupScreen.tsx
@@ -11,8 +11,18 @@ import {
 } from 'react-native';
 import { AtmosphereBackground } from './AtmosphereBackground';
 import { palette, radius, type } from './theme';
-import type { UserProfile } from './AuthScreen';
-import type { BodyMeasurements } from './types';
+import type { UserProfile as AuthUserProfile } from './AuthScreen';
+import type {
+  AvatarConfig,
+  BodyMeasurements,
+  ColorTone,
+  SkinTone,
+  UserProfileUpdate,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function isValidBirthday(value: string): boolean {
   const v = value.trim();
@@ -34,42 +44,581 @@ function parsePositiveFloat(value: string): number | null {
 
 type MeasurementFields = Omit<BodyMeasurements, 'userId' | 'updatedAt'>;
 
+// ---------------------------------------------------------------------------
+// Step progress indicator
+// ---------------------------------------------------------------------------
+
+function StepDots({ total, current }: { total: number; current: number }) {
+  return (
+    <View style={stepStyles.dotsRow}>
+      {Array.from({ length: total }, (_, i) => (
+        <View
+          key={i}
+          style={[stepStyles.dot, i === current && stepStyles.dotActive]}
+        />
+      ))}
+    </View>
+  );
+}
+
+const stepStyles = StyleSheet.create({
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 24,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: palette.lineStrong,
+  },
+  dotActive: {
+    backgroundColor: palette.accent,
+    width: 20,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Shared sub-components
+// ---------------------------------------------------------------------------
+
+function SectionLabel({ children, style }: { children: string; style?: object }) {
+  return <Text style={[shared.sectionTitle, style]}>{children}</Text>;
+}
+
+function ChipRow<T extends string>({
+  options,
+  value,
+  onSelect,
+  multiSelect = false,
+  selectedValues,
+  onMultiSelect,
+}: {
+  options: { key: T; label: string }[];
+  value?: T | null;
+  onSelect?: (v: T | null) => void;
+  multiSelect?: boolean;
+  selectedValues?: T[];
+  onMultiSelect?: (v: T[]) => void;
+}) {
+  return (
+    <View style={shared.row}>
+      {options.map((opt) => {
+        const active = multiSelect
+          ? (selectedValues ?? []).includes(opt.key)
+          : value === opt.key;
+        return (
+          <Pressable
+            key={opt.key}
+            onPress={() => {
+              if (multiSelect && onMultiSelect && selectedValues !== undefined) {
+                if (active) {
+                  onMultiSelect(selectedValues.filter((v) => v !== opt.key));
+                } else {
+                  onMultiSelect([...selectedValues, opt.key]);
+                }
+              } else if (!multiSelect && onSelect) {
+                onSelect(active ? null : opt.key);
+              }
+            }}
+            style={[shared.chip, active && shared.chipActive]}
+          >
+            <Text style={[shared.chipText, active && shared.chipTextActive]}>
+              {opt.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+// Colour swatch selector
+function ColorSwatchRow({
+  colors,
+  selectedValues,
+  onToggle,
+}: {
+  colors: { key: string; label: string; hex: string }[];
+  selectedValues: string[];
+  onToggle: (key: string) => void;
+}) {
+  return (
+    <View style={shared.swatchRow}>
+      {colors.map((c) => {
+        const active = selectedValues.includes(c.key);
+        return (
+          <Pressable key={c.key} onPress={() => onToggle(c.key)} style={shared.swatchItem}>
+            <View
+              style={[
+                shared.swatch,
+                { backgroundColor: c.hex },
+                active && shared.swatchActive,
+              ]}
+            />
+            <Text style={[shared.swatchLabel, active && shared.swatchLabelActive]}>
+              {c.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Data constants
+// ---------------------------------------------------------------------------
+
+const SKIN_TONES: { key: SkinTone; label: string; hex: string }[] = [
+  { key: 'very_light', label: 'Very Light', hex: '#FDDBB4' },
+  { key: 'light', label: 'Light', hex: '#F5C5A3' },
+  { key: 'medium_light', label: 'Medium Light', hex: '#D4956A' },
+  { key: 'medium', label: 'Medium', hex: '#B46A3C' },
+  { key: 'medium_dark', label: 'Medium Dark', hex: '#8D4A24' },
+  { key: 'dark', label: 'Dark', hex: '#4A2515' },
+];
+
+const COLOR_TONE_OPTIONS: { key: ColorTone; label: string }[] = [
+  { key: 'warm', label: 'Warm' },
+  { key: 'cool', label: 'Cool' },
+  { key: 'neutral', label: 'Neutral' },
+];
+
+const PALETTE_COLORS = [
+  { key: 'black', label: 'Black', hex: '#111111' },
+  { key: 'white', label: 'White', hex: '#F5F5F0' },
+  { key: 'grey', label: 'Grey', hex: '#9E9E9E' },
+  { key: 'navy', label: 'Navy', hex: '#1A2E5C' },
+  { key: 'blue', label: 'Blue', hex: '#2979FF' },
+  { key: 'green', label: 'Green', hex: '#2E7D32' },
+  { key: 'olive', label: 'Olive', hex: '#6D6E32' },
+  { key: 'brown', label: 'Brown', hex: '#795548' },
+  { key: 'beige', label: 'Beige', hex: '#D4B896' },
+  { key: 'red', label: 'Red', hex: '#C62828' },
+  { key: 'pink', label: 'Pink', hex: '#E91E8C' },
+  { key: 'yellow', label: 'Yellow', hex: '#F9A825' },
+];
+
+const SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
+
+const HAIR_STYLES = [
+  { key: 'short_straight', label: 'Short Straight' },
+  { key: 'short_wavy', label: 'Short Wavy' },
+  { key: 'long_straight', label: 'Long Straight' },
+  { key: 'long_wavy', label: 'Long Wavy' },
+  { key: 'curly_afro', label: 'Curly / Afro' },
+  { key: 'bald', label: 'Bald / Shaved' },
+];
+
+const HAIR_COLORS = [
+  { key: 'black', label: 'Black' },
+  { key: 'dark_brown', label: 'Dark Brown' },
+  { key: 'light_brown', label: 'Light Brown' },
+  { key: 'auburn', label: 'Auburn' },
+  { key: 'blonde', label: 'Blonde' },
+  { key: 'red', label: 'Red' },
+  { key: 'grey', label: 'Grey' },
+  { key: 'white', label: 'White' },
+];
+
+const BODY_TYPES = [
+  { key: 'slim', label: 'Slim / Athletic' },
+  { key: 'average', label: 'Average' },
+  { key: 'broad', label: 'Broad / Plus' },
+];
+
+// ---------------------------------------------------------------------------
+// Step 1 — Personal info + measurements (original screen content)
+// ---------------------------------------------------------------------------
+
+interface Step1State {
+  gender: AuthUserProfile['gender'];
+  birthday: string;
+  heightCm: string;
+  weightKg: string;
+  chestCm: string;
+  waistCm: string;
+  hipsCm: string;
+  inseamCm: string;
+}
+
+function Step1({
+  state,
+  onChange,
+}: {
+  state: Step1State;
+  onChange: (patch: Partial<Step1State>) => void;
+}) {
+  const [birthdayTouched, setBirthdayTouched] = useState(false);
+  const [showMeasurements, setShowMeasurements] = useState(false);
+
+  const birthdayError = useMemo(() => {
+    const v = state.birthday.trim();
+    if (!birthdayTouched || !v) return null;
+    return isValidBirthday(v) ? null : 'Use YYYY-MM-DD (e.g., 2001-04-07).';
+  }, [state.birthday, birthdayTouched]);
+
+  return (
+    <>
+      <View style={styles.card}>
+        <SectionLabel>Gender</SectionLabel>
+        <ChipRow
+          options={[
+            { key: 'female', label: 'Female' },
+            { key: 'male', label: 'Male' },
+            { key: 'other', label: 'Other' },
+          ]}
+          value={state.gender}
+          onSelect={(v) => onChange({ gender: v as AuthUserProfile['gender'] })}
+        />
+
+        <SectionLabel style={{ marginTop: 16 }}>Birthday</SectionLabel>
+        <TextInput
+          value={state.birthday}
+          onChangeText={(v) => onChange({ birthday: v })}
+          placeholder="YYYY-MM-DD (optional)"
+          placeholderTextColor={palette.muted}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType={Platform.OS === 'web' ? 'default' : 'numbers-and-punctuation'}
+          style={[styles.input, birthdayError ? styles.inputError : undefined]}
+          onBlur={() => setBirthdayTouched(true)}
+        />
+        {birthdayError ? <Text style={styles.errorText}>{birthdayError}</Text> : null}
+      </View>
+
+      <Pressable
+        style={styles.measurementsToggle}
+        onPress={() => setShowMeasurements((v) => !v)}
+      >
+        <Text style={styles.measurementsToggleText}>
+          {showMeasurements ? '▲ Hide' : '▼ Add'} body measurements (optional)
+        </Text>
+      </Pressable>
+
+      {showMeasurements ? (
+        <View style={styles.card}>
+          <Text style={styles.measurementsHint}>
+            Used to suggest better-fitting items. All fields are optional and stored securely.
+          </Text>
+          {(
+            [
+              { label: 'Height (cm)', key: 'heightCm' },
+              { label: 'Weight (kg)', key: 'weightKg' },
+              { label: 'Chest / Bust (cm)', key: 'chestCm' },
+              { label: 'Waist (cm)', key: 'waistCm' },
+              { label: 'Hips (cm)', key: 'hipsCm' },
+              { label: 'Inseam (cm)', key: 'inseamCm' },
+            ] as const
+          ).map(({ label, key }) => (
+            <View key={label} style={styles.measurementRow}>
+              <Text style={styles.measurementLabel}>{label}</Text>
+              <TextInput
+                value={state[key]}
+                onChangeText={(v) => onChange({ [key]: v })}
+                placeholder="—"
+                placeholderTextColor={palette.muted}
+                keyboardType="decimal-pad"
+                style={styles.measurementInput}
+              />
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Colour preferences
+// ---------------------------------------------------------------------------
+
+interface Step2State {
+  skinTone: SkinTone | null;
+  colorTone: ColorTone | null;
+  favoriteColors: string[];
+  avoidedColors: string[];
+}
+
+function Step2({
+  state,
+  onChange,
+}: {
+  state: Step2State;
+  onChange: (patch: Partial<Step2State>) => void;
+}) {
+  return (
+    <>
+      <View style={styles.card}>
+        <SectionLabel>Skin Tone</SectionLabel>
+        <View style={shared.swatchRow}>
+          {SKIN_TONES.map((st) => {
+            const active = state.skinTone === st.key;
+            return (
+              <Pressable
+                key={st.key}
+                onPress={() => onChange({ skinTone: active ? null : st.key })}
+                style={shared.swatchItem}
+              >
+                <View
+                  style={[
+                    shared.swatch,
+                    { backgroundColor: st.hex },
+                    active && shared.swatchActive,
+                  ]}
+                />
+                <Text style={[shared.swatchLabel, active && shared.swatchLabelActive]}>
+                  {st.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      <View style={styles.card}>
+        <SectionLabel>Colour Tone</SectionLabel>
+        <Text style={styles.measurementsHint}>
+          Warm tones (reds, oranges, yellows) or Cool tones (blues, purples, greens)?
+        </Text>
+        <ChipRow
+          options={COLOR_TONE_OPTIONS}
+          value={state.colorTone}
+          onSelect={(v) => onChange({ colorTone: v as ColorTone | null })}
+        />
+      </View>
+
+      <View style={styles.card}>
+        <SectionLabel>Favourite Colours</SectionLabel>
+        <Text style={styles.measurementsHint}>
+          We'll prioritise these in outfit suggestions.
+        </Text>
+        <ColorSwatchRow
+          colors={PALETTE_COLORS}
+          selectedValues={state.favoriteColors}
+          onToggle={(key) => {
+            const next = state.favoriteColors.includes(key)
+              ? state.favoriteColors.filter((c) => c !== key)
+              : [...state.favoriteColors, key];
+            onChange({ favoriteColors: next });
+          }}
+        />
+      </View>
+
+      <View style={styles.card}>
+        <SectionLabel>Colours to Avoid</SectionLabel>
+        <Text style={styles.measurementsHint}>
+          We'll de-prioritise these in outfit suggestions.
+        </Text>
+        <ColorSwatchRow
+          colors={PALETTE_COLORS}
+          selectedValues={state.avoidedColors}
+          onToggle={(key) => {
+            const next = state.avoidedColors.includes(key)
+              ? state.avoidedColors.filter((c) => c !== key)
+              : [...state.avoidedColors, key];
+            onChange({ avoidedColors: next });
+          }}
+        />
+      </View>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — Sizes + avatar
+// ---------------------------------------------------------------------------
+
+interface Step3State {
+  topSize: string | null;
+  bottomSize: string | null;
+  shoeSize: string;
+  hairStyle: string | null;
+  hairColor: string | null;
+  bodyType: string | null;
+}
+
+function Step3({
+  state,
+  onChange,
+}: {
+  state: Step3State;
+  onChange: (patch: Partial<Step3State>) => void;
+}) {
+  return (
+    <>
+      <View style={styles.card}>
+        <SectionLabel>Top Size</SectionLabel>
+        <ChipRow
+          options={SIZE_OPTIONS.map((s) => ({ key: s, label: s }))}
+          value={state.topSize}
+          onSelect={(v) => onChange({ topSize: v })}
+        />
+
+        <SectionLabel style={{ marginTop: 16 }}>Bottom Size</SectionLabel>
+        <ChipRow
+          options={SIZE_OPTIONS.map((s) => ({ key: s, label: s }))}
+          value={state.bottomSize}
+          onSelect={(v) => onChange({ bottomSize: v })}
+        />
+
+        <SectionLabel style={{ marginTop: 16 }}>Shoe Size (EU / US)</SectionLabel>
+        <TextInput
+          value={state.shoeSize}
+          onChangeText={(v) => onChange({ shoeSize: v })}
+          placeholder="e.g. 42 or 9"
+          placeholderTextColor={palette.muted}
+          keyboardType="decimal-pad"
+          style={styles.input}
+        />
+      </View>
+
+      <View style={styles.card}>
+        <SectionLabel>Avatar — Hair Style</SectionLabel>
+        <ChipRow
+          options={HAIR_STYLES}
+          value={state.hairStyle}
+          onSelect={(v) => onChange({ hairStyle: v })}
+        />
+
+        <SectionLabel style={{ marginTop: 16 }}>Hair Colour</SectionLabel>
+        <ChipRow
+          options={HAIR_COLORS}
+          value={state.hairColor}
+          onSelect={(v) => onChange({ hairColor: v })}
+        />
+
+        <SectionLabel style={{ marginTop: 16 }}>Body Type</SectionLabel>
+        <ChipRow
+          options={BODY_TYPES}
+          value={state.bodyType}
+          onSelect={(v) => onChange({ bodyType: v })}
+        />
+      </View>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main wizard component
+// ---------------------------------------------------------------------------
+
+const TOTAL_STEPS = 3;
+
+const STEP_TITLES = [
+  'About you',
+  'Your colour style',
+  'Sizes & avatar',
+];
+
+const STEP_SUBTITLES = [
+  'Helps tailor fit and recommendations.',
+  'We\'ll match colours that suit your palette.',
+  'Used for size filtering and outfit previews.',
+];
+
+export interface ProfileSetupResult {
+  profilePatch: Pick<AuthUserProfile, 'gender' | 'birthday'>;
+  measurements: MeasurementFields;
+  profileUpdate: UserProfileUpdate;
+}
+
 export function ProfileSetupScreen({
   initialProfile,
   onDone,
 }: {
-  initialProfile?: UserProfile;
-  onDone: (profilePatch: Pick<UserProfile, 'gender' | 'birthday'>, measurements: MeasurementFields) => void;
+  initialProfile?: AuthUserProfile;
+  onDone: (result: ProfileSetupResult) => void;
 }) {
-  const [gender, setGender] = useState<UserProfile['gender']>(initialProfile?.gender ?? null);
-  const [birthday, setBirthday] = useState<string>(initialProfile?.birthday ?? '');
-  const [birthdayTouched, setBirthdayTouched] = useState(false);
+  const [step, setStep] = useState(0);
 
-  const [showMeasurements, setShowMeasurements] = useState(false);
-  const [heightCm, setHeightCm] = useState('');
-  const [weightKg, setWeightKg] = useState('');
-  const [chestCm, setChestCm] = useState('');
-  const [waistCm, setWaistCm] = useState('');
-  const [hipsCm, setHipsCm] = useState('');
-  const [inseamCm, setInseamCm] = useState('');
+  const [step1, setStep1] = useState<Step1State>({
+    gender: initialProfile?.gender ?? null,
+    birthday: initialProfile?.birthday ?? '',
+    heightCm: '',
+    weightKg: '',
+    chestCm: '',
+    waistCm: '',
+    hipsCm: '',
+    inseamCm: '',
+  });
 
-  const birthdayError = useMemo(() => {
-    const value = birthday.trim();
-    if (!birthdayTouched) return null;
-    if (!value) return null;
-    return isValidBirthday(value) ? null : 'Use YYYY-MM-DD (e.g., 2001-04-07).';
-  }, [birthday, birthdayTouched]);
+  const [step2, setStep2] = useState<Step2State>({
+    skinTone: null,
+    colorTone: null,
+    favoriteColors: [],
+    avoidedColors: [],
+  });
 
-  function buildMeasurements(): MeasurementFields {
+  const [step3, setStep3] = useState<Step3State>({
+    topSize: null,
+    bottomSize: null,
+    shoeSize: '',
+    hairStyle: null,
+    hairColor: null,
+    bodyType: null,
+  });
+
+  function buildResult(skipped = false): ProfileSetupResult {
+    const measurements: MeasurementFields = skipped
+      ? { heightCm: null, weightKg: null, chestCm: null, waistCm: null, hipsCm: null, inseamCm: null }
+      : {
+          heightCm: parsePositiveFloat(step1.heightCm),
+          weightKg: parsePositiveFloat(step1.weightKg),
+          chestCm: parsePositiveFloat(step1.chestCm),
+          waistCm: parsePositiveFloat(step1.waistCm),
+          hipsCm: parsePositiveFloat(step1.hipsCm),
+          inseamCm: parsePositiveFloat(step1.inseamCm),
+        };
+
+    const avatarConfig: AvatarConfig | null =
+      step3.hairStyle || step3.hairColor || step3.bodyType
+        ? {
+            hairStyle: step3.hairStyle,
+            hairColor: step3.hairColor,
+            bodyType: step3.bodyType,
+            skinTone: step2.skinTone,
+          }
+        : null;
+
+    const profileUpdate: UserProfileUpdate = {
+      gender: skipped ? null : (step1.gender ?? null),
+      birthday: skipped ? null : (step1.birthday.trim() || null),
+      skinTone: step2.skinTone,
+      colorTone: step2.colorTone,
+      favoriteColors: step2.favoriteColors,
+      avoidedColors: step2.avoidedColors,
+      topSize: step3.topSize,
+      bottomSize: step3.bottomSize,
+      shoeSize: step3.shoeSize.trim() || null,
+      avatarConfig,
+    };
+
     return {
-      heightCm: parsePositiveFloat(heightCm),
-      weightKg: parsePositiveFloat(weightKg),
-      chestCm: parsePositiveFloat(chestCm),
-      waistCm: parsePositiveFloat(waistCm),
-      hipsCm: parsePositiveFloat(hipsCm),
-      inseamCm: parsePositiveFloat(inseamCm),
+      profilePatch: {
+        gender: skipped ? null : (step1.gender ?? null),
+        birthday: skipped ? null : (step1.birthday.trim() || null),
+      },
+      measurements,
+      profileUpdate,
     };
   }
+
+  function handleNext() {
+    if (step < TOTAL_STEPS - 1) {
+      setStep((s) => s + 1);
+    } else {
+      onDone(buildResult(false));
+    }
+  }
+
+  function handleBack() {
+    setStep((s) => Math.max(0, s - 1));
+  }
+
+  const isLastStep = step === TOTAL_STEPS - 1;
 
   return (
     <SafeAreaView style={styles.safe}>
@@ -79,126 +628,123 @@ export function ProfileSetupScreen({
         keyboardShouldPersistTaps="handled"
       >
         <Text style={styles.brand}>misfitAI</Text>
-        <Text style={styles.title}>A quick question</Text>
-        <Text style={styles.subtitle}>
-          Optional — helps tailor recommendations.
-        </Text>
+        <StepDots total={TOTAL_STEPS} current={step} />
+        <Text style={styles.title}>{STEP_TITLES[step]}</Text>
+        <Text style={styles.subtitle}>{STEP_SUBTITLES[step]}</Text>
 
-        <View style={styles.card}>
-          <Text style={styles.sectionTitle}>Gender</Text>
-          <View style={styles.row}>
-            {([
-              { key: 'female', label: 'Female' },
-              { key: 'male', label: 'Male' },
-              { key: 'other', label: 'Other' },
-            ] as const).map((g) => {
-              const active = gender === g.key;
-              return (
-                <Pressable
-                  key={g.key}
-                  onPress={() => setGender(active ? null : g.key)}
-                  style={[styles.chip, active && styles.chipActive]}
-                >
-                  <Text style={[styles.chipText, active && styles.chipTextActive]}>
-                    {g.label}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </View>
-
-          <Text style={[styles.sectionTitle, { marginTop: 16 }]}>Birthday</Text>
-          <TextInput
-            value={birthday}
-            onChangeText={setBirthday}
-            placeholder="YYYY-MM-DD (optional)"
-            placeholderTextColor={palette.muted}
-            autoCapitalize="none"
-            autoCorrect={false}
-            keyboardType={Platform.OS === 'web' ? 'default' : 'numbers-and-punctuation'}
-            style={[styles.input, birthdayError && styles.inputError]}
-            onBlur={() => setBirthdayTouched(true)}
+        {step === 0 && (
+          <Step1
+            state={step1}
+            onChange={(patch) => setStep1((s) => ({ ...s, ...patch }))}
           />
-          {birthdayError ? <Text style={styles.errorText}>{birthdayError}</Text> : null}
-        </View>
-
-        {/* Body measurements — collapsible section */}
-        <Pressable
-          style={styles.measurementsToggle}
-          onPress={() => setShowMeasurements((v) => !v)}
-        >
-          <Text style={styles.measurementsToggleText}>
-            {showMeasurements ? '▲ Hide' : '▼ Add'} body measurements (optional)
-          </Text>
-        </Pressable>
-
-        {showMeasurements ? (
-          <View style={styles.card}>
-            <Text style={styles.measurementsHint}>
-              Used to suggest better-fitting items. All fields are optional and stored
-              securely.
-            </Text>
-            {(
-              [
-                { label: 'Height (cm)', value: heightCm, onChange: setHeightCm },
-                { label: 'Weight (kg)', value: weightKg, onChange: setWeightKg },
-                { label: 'Chest / Bust (cm)', value: chestCm, onChange: setChestCm },
-                { label: 'Waist (cm)', value: waistCm, onChange: setWaistCm },
-                { label: 'Hips (cm)', value: hipsCm, onChange: setHipsCm },
-                { label: 'Inseam (cm)', value: inseamCm, onChange: setInseamCm },
-              ] as const
-            ).map(({ label, value, onChange }) => (
-              <View key={label} style={styles.measurementRow}>
-                <Text style={styles.measurementLabel}>{label}</Text>
-                <TextInput
-                  value={value}
-                  onChangeText={onChange}
-                  placeholder="—"
-                  placeholderTextColor={palette.muted}
-                  keyboardType="decimal-pad"
-                  style={styles.measurementInput}
-                />
-              </View>
-            ))}
-          </View>
-        ) : null}
+        )}
+        {step === 1 && (
+          <Step2
+            state={step2}
+            onChange={(patch) => setStep2((s) => ({ ...s, ...patch }))}
+          />
+        )}
+        {step === 2 && (
+          <Step3
+            state={step3}
+            onChange={(patch) => setStep3((s) => ({ ...s, ...patch }))}
+          />
+        )}
 
         <View style={styles.actions}>
-          <Pressable
-            onPress={() =>
-              onDone({ gender: null, birthday: null }, {
-                heightCm: null,
-                weightKg: null,
-                chestCm: null,
-                waistCm: null,
-                hipsCm: null,
-                inseamCm: null,
-              })
-            }
-            style={[styles.button, styles.buttonGhost]}
-          >
-            <Text style={[styles.buttonText, styles.buttonGhostText]}>Skip</Text>
-          </Pressable>
-          <Pressable
-            onPress={() =>
-              onDone(
-                {
-                  gender: gender ?? null,
-                  birthday: birthday.trim() ? birthday.trim() : null,
-                },
-                buildMeasurements()
-              )
-            }
-            style={[styles.button, styles.buttonPrimary]}
-            disabled={Boolean(birthdayError)}
-          >
-            <Text style={[styles.buttonText, styles.buttonPrimaryText]}>Continue</Text>
+          {step === 0 ? (
+            <Pressable
+              onPress={() => onDone(buildResult(true))}
+              style={[styles.button, styles.buttonGhost]}
+            >
+              <Text style={[styles.buttonText, styles.buttonGhostText]}>Skip all</Text>
+            </Pressable>
+          ) : (
+            <Pressable onPress={handleBack} style={[styles.button, styles.buttonGhost]}>
+              <Text style={[styles.buttonText, styles.buttonGhostText]}>Back</Text>
+            </Pressable>
+          )}
+          <Pressable onPress={handleNext} style={[styles.button, styles.buttonPrimary]}>
+            <Text style={[styles.buttonText, styles.buttonPrimaryText]}>
+              {isLastStep ? 'Finish' : 'Next'}
+            </Text>
           </Pressable>
         </View>
       </ScrollView>
     </SafeAreaView>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const shared = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  chip: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  chipActive: {
+    backgroundColor: palette.accent,
+    borderColor: palette.accent,
+  },
+  chipText: {
+    fontSize: 13,
+    color: palette.inkSoft,
+    fontFamily: type.bodyMedium,
+  },
+  chipTextActive: {
+    color: palette.panelStrong,
+  },
+  swatchRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    marginTop: 4,
+  },
+  swatchItem: {
+    alignItems: 'center',
+    width: 52,
+  },
+  swatch: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  swatchActive: {
+    borderColor: palette.accent,
+  },
+  swatchLabel: {
+    fontSize: 10,
+    color: palette.muted,
+    fontFamily: type.body,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  swatchLabelActive: {
+    color: palette.ink,
+    fontFamily: type.bodyDemi,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    color: palette.muted,
+    fontFamily: type.bodyDemi,
+    marginBottom: 10,
+  },
+});
 
 const styles = StyleSheet.create({
   safe: {
@@ -236,39 +782,6 @@ const styles = StyleSheet.create({
     backgroundColor: palette.panel,
     padding: 16,
     marginBottom: 12,
-  },
-  sectionTitle: {
-    fontSize: 12,
-    letterSpacing: 0.6,
-    textTransform: 'uppercase',
-    color: palette.muted,
-    fontFamily: type.bodyDemi,
-    marginBottom: 10,
-  },
-  row: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 10,
-  },
-  chip: {
-    borderRadius: radius.pill,
-    borderWidth: 1,
-    borderColor: palette.lineStrong,
-    backgroundColor: palette.panelStrong,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-  },
-  chipActive: {
-    backgroundColor: palette.accent,
-    borderColor: palette.accent,
-  },
-  chipText: {
-    fontSize: 13,
-    color: palette.inkSoft,
-    fontFamily: type.bodyMedium,
-  },
-  chipTextActive: {
-    color: palette.panelStrong,
   },
   input: {
     borderRadius: radius.md,

--- a/misfitai-mobile/src/ProfileSetupScreen.tsx
+++ b/misfitai-mobile/src/ProfileSetupScreen.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import {
+  Alert,
+  Image,
   Platform,
   Pressable,
   SafeAreaView,
@@ -9,6 +11,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { AtmosphereBackground } from './AtmosphereBackground';
 import { palette, radius, type } from './theme';
 import type { UserProfile as AuthUserProfile } from './AuthScreen';
@@ -247,18 +250,20 @@ interface Step1State {
 function Step1({
   state,
   onChange,
+  forceTouched = false,
 }: {
   state: Step1State;
   onChange: (patch: Partial<Step1State>) => void;
+  forceTouched?: boolean;
 }) {
   const [birthdayTouched, setBirthdayTouched] = useState(false);
   const [showMeasurements, setShowMeasurements] = useState(false);
 
   const birthdayError = useMemo(() => {
     const v = state.birthday.trim();
-    if (!birthdayTouched || !v) return null;
+    if (!(birthdayTouched || forceTouched) || !v) return null;
     return isValidBirthday(v) ? null : 'Use YYYY-MM-DD (e.g., 2001-04-07).';
-  }, [state.birthday, birthdayTouched]);
+  }, [state.birthday, birthdayTouched, forceTouched]);
 
   return (
     <>
@@ -438,6 +443,7 @@ interface Step3State {
   hairStyle: string | null;
   hairColor: string | null;
   bodyType: string | null;
+  selfieUri: string | null;
 }
 
 function Step3({
@@ -447,6 +453,44 @@ function Step3({
   state: Step3State;
   onChange: (patch: Partial<Step3State>) => void;
 }) {
+  async function handlePickSelfie(fromCamera: boolean) {
+    if (fromCamera) {
+      const { status } = await ImagePicker.requestCameraPermissionsAsync();
+      if (status !== 'granted') {
+        Alert.alert('Camera permission required', 'Please allow camera access in Settings.');
+        return;
+      }
+    }
+    const result = fromCamera
+      ? await ImagePicker.launchCameraAsync({
+          mediaTypes: ['images'],
+          allowsEditing: true,
+          aspect: [1, 1],
+          quality: 0.8,
+        })
+      : await ImagePicker.launchImageLibraryAsync({
+          mediaTypes: ['images'],
+          allowsEditing: true,
+          aspect: [1, 1],
+          quality: 0.8,
+        });
+    if (!result.canceled && result.assets?.[0]?.uri) {
+      onChange({ selfieUri: result.assets[0].uri });
+    }
+  }
+
+  function promptSource() {
+    Alert.alert(
+      'Add a selfie',
+      'Used to generate your personalised avatar',
+      [
+        { text: 'Take selfie', onPress: () => void handlePickSelfie(true) },
+        { text: 'Choose from library', onPress: () => void handlePickSelfie(false) },
+        { text: 'Cancel', style: 'cancel' },
+      ]
+    );
+  }
+
   return (
     <>
       <View style={styles.card}>
@@ -497,9 +541,66 @@ function Step3({
           onSelect={(v) => onChange({ bodyType: v })}
         />
       </View>
+
+      {/* Optional selfie for avatar generation */}
+      <View style={styles.card}>
+        <SectionLabel>Selfie for Avatar Generation</SectionLabel>
+        <Text style={styles.measurementsHint}>
+          Optional — snap a selfie and we'll use it (plus the details above) to generate a
+          personalised illustrated avatar. Your selfie is never stored.
+        </Text>
+        {state.selfieUri ? (
+          <Image
+            source={{ uri: state.selfieUri }}
+            style={selfieStyles.preview}
+            resizeMode="cover"
+          />
+        ) : null}
+        <Pressable onPress={promptSource} style={selfieStyles.btn}>
+          <Text style={selfieStyles.btnText}>
+            {state.selfieUri ? '📷 Retake / Change selfie' : '📷 Take or choose selfie'}
+          </Text>
+        </Pressable>
+        {state.selfieUri ? (
+          <Pressable onPress={() => onChange({ selfieUri: null })} style={selfieStyles.removeBtn}>
+            <Text style={selfieStyles.removeBtnText}>Remove</Text>
+          </Pressable>
+        ) : null}
+      </View>
     </>
   );
 }
+
+const selfieStyles = StyleSheet.create({
+  preview: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: radius.md,
+    backgroundColor: palette.bgAlt,
+    marginBottom: 10,
+  },
+  btn: {
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: palette.accent,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  btnText: {
+    fontSize: 13,
+    color: palette.accent,
+    fontFamily: type.bodyDemi,
+  },
+  removeBtn: {
+    marginTop: 8,
+    alignItems: 'center',
+  },
+  removeBtnText: {
+    fontSize: 12,
+    color: palette.error,
+    fontFamily: type.body,
+  },
+});
 
 // ---------------------------------------------------------------------------
 // Main wizard component
@@ -523,6 +624,8 @@ export interface ProfileSetupResult {
   profilePatch: Pick<AuthUserProfile, 'gender' | 'birthday'>;
   measurements: MeasurementFields;
   profileUpdate: UserProfileUpdate;
+  /** Local file URI of the selfie, if the user provided one. Used to trigger avatar generation. */
+  selfieUri: string | null;
 }
 
 export function ProfileSetupScreen({
@@ -559,7 +662,12 @@ export function ProfileSetupScreen({
     hairStyle: null,
     hairColor: null,
     bodyType: null,
+    selfieUri: null,
   });
+
+  // Controlled "force-show errors" flag for Step 1's birthday field.
+  // Set to true when the user attempts to advance with an invalid date.
+  const [forceStep1Touched, setForceStep1Touched] = useState(false);
 
   function buildResult(skipped = false): ProfileSetupResult {
     const measurements: MeasurementFields = skipped
@@ -603,10 +711,20 @@ export function ProfileSetupScreen({
       },
       measurements,
       profileUpdate,
+      selfieUri: skipped ? null : (step3.selfieUri ?? null),
     };
   }
 
   function handleNext() {
+    // Guard: block advancement from Step 1 if the birthday field has a value
+    // but it fails validation.  Force the error UI to show.
+    if (step === 0) {
+      const bd = step1.birthday.trim();
+      if (bd && !isValidBirthday(bd)) {
+        setForceStep1Touched(true);
+        return;
+      }
+    }
     if (step < TOTAL_STEPS - 1) {
       setStep((s) => s + 1);
     } else {
@@ -636,6 +754,7 @@ export function ProfileSetupScreen({
           <Step1
             state={step1}
             onChange={(patch) => setStep1((s) => ({ ...s, ...patch }))}
+            forceTouched={forceStep1Touched}
           />
         )}
         {step === 1 && (

--- a/misfitai-mobile/src/ProfileSetupScreen.tsx
+++ b/misfitai-mobile/src/ProfileSetupScreen.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import {
-  Alert,
-  Image,
   Platform,
   Pressable,
   SafeAreaView,
@@ -11,7 +9,6 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import * as ImagePicker from 'expo-image-picker';
 import { AtmosphereBackground } from './AtmosphereBackground';
 import { palette, radius, type } from './theme';
 import type { UserProfile as AuthUserProfile } from './AuthScreen';
@@ -443,7 +440,6 @@ interface Step3State {
   hairStyle: string | null;
   hairColor: string | null;
   bodyType: string | null;
-  selfieUri: string | null;
 }
 
 function Step3({
@@ -453,44 +449,6 @@ function Step3({
   state: Step3State;
   onChange: (patch: Partial<Step3State>) => void;
 }) {
-  async function handlePickSelfie(fromCamera: boolean) {
-    if (fromCamera) {
-      const { status } = await ImagePicker.requestCameraPermissionsAsync();
-      if (status !== 'granted') {
-        Alert.alert('Camera permission required', 'Please allow camera access in Settings.');
-        return;
-      }
-    }
-    const result = fromCamera
-      ? await ImagePicker.launchCameraAsync({
-          mediaTypes: ['images'],
-          allowsEditing: true,
-          aspect: [1, 1],
-          quality: 0.8,
-        })
-      : await ImagePicker.launchImageLibraryAsync({
-          mediaTypes: ['images'],
-          allowsEditing: true,
-          aspect: [1, 1],
-          quality: 0.8,
-        });
-    if (!result.canceled && result.assets?.[0]?.uri) {
-      onChange({ selfieUri: result.assets[0].uri });
-    }
-  }
-
-  function promptSource() {
-    Alert.alert(
-      'Add a selfie',
-      'Used to generate your personalised avatar',
-      [
-        { text: 'Take selfie', onPress: () => void handlePickSelfie(true) },
-        { text: 'Choose from library', onPress: () => void handlePickSelfie(false) },
-        { text: 'Cancel', style: 'cancel' },
-      ]
-    );
-  }
-
   return (
     <>
       <View style={styles.card}>
@@ -541,66 +499,9 @@ function Step3({
           onSelect={(v) => onChange({ bodyType: v })}
         />
       </View>
-
-      {/* Optional selfie for avatar generation */}
-      <View style={styles.card}>
-        <SectionLabel>Selfie for Avatar Generation</SectionLabel>
-        <Text style={styles.measurementsHint}>
-          Optional — snap a selfie and we'll use it (plus the details above) to generate a
-          personalised illustrated avatar. Your selfie is never stored.
-        </Text>
-        {state.selfieUri ? (
-          <Image
-            source={{ uri: state.selfieUri }}
-            style={selfieStyles.preview}
-            resizeMode="cover"
-          />
-        ) : null}
-        <Pressable onPress={promptSource} style={selfieStyles.btn}>
-          <Text style={selfieStyles.btnText}>
-            {state.selfieUri ? '📷 Retake / Change selfie' : '📷 Take or choose selfie'}
-          </Text>
-        </Pressable>
-        {state.selfieUri ? (
-          <Pressable onPress={() => onChange({ selfieUri: null })} style={selfieStyles.removeBtn}>
-            <Text style={selfieStyles.removeBtnText}>Remove</Text>
-          </Pressable>
-        ) : null}
-      </View>
     </>
   );
 }
-
-const selfieStyles = StyleSheet.create({
-  preview: {
-    width: '100%',
-    aspectRatio: 1,
-    borderRadius: radius.md,
-    backgroundColor: palette.bgAlt,
-    marginBottom: 10,
-  },
-  btn: {
-    borderRadius: radius.md,
-    borderWidth: 1,
-    borderColor: palette.accent,
-    paddingVertical: 10,
-    alignItems: 'center',
-  },
-  btnText: {
-    fontSize: 13,
-    color: palette.accent,
-    fontFamily: type.bodyDemi,
-  },
-  removeBtn: {
-    marginTop: 8,
-    alignItems: 'center',
-  },
-  removeBtnText: {
-    fontSize: 12,
-    color: palette.error,
-    fontFamily: type.body,
-  },
-});
 
 // ---------------------------------------------------------------------------
 // Main wizard component
@@ -624,8 +525,6 @@ export interface ProfileSetupResult {
   profilePatch: Pick<AuthUserProfile, 'gender' | 'birthday'>;
   measurements: MeasurementFields;
   profileUpdate: UserProfileUpdate;
-  /** Local file URI of the selfie, if the user provided one. Used to trigger avatar generation. */
-  selfieUri: string | null;
 }
 
 export function ProfileSetupScreen({
@@ -662,7 +561,6 @@ export function ProfileSetupScreen({
     hairStyle: null,
     hairColor: null,
     bodyType: null,
-    selfieUri: null,
   });
 
   // Controlled "force-show errors" flag for Step 1's birthday field.
@@ -711,7 +609,6 @@ export function ProfileSetupScreen({
       },
       measurements,
       profileUpdate,
-      selfieUri: skipped ? null : (step3.selfieUri ?? null),
     };
   }
 

--- a/misfitai-mobile/src/__tests__/api.test.ts
+++ b/misfitai-mobile/src/__tests__/api.test.ts
@@ -218,7 +218,6 @@ describe('profileUpdateToApiPayload', () => {
         hairColor: 'black',
         bodyType: 'slim',
         skinTone: 'medium_dark',
-        avatarImageUrl: 'https://example.com/av.jpg',
       },
     });
     const cfg = payload.avatar_config as Record<string, unknown>;
@@ -227,7 +226,6 @@ describe('profileUpdateToApiPayload', () => {
     expect(cfg.hair_color).toBe('black');
     expect(cfg.body_type).toBe('slim');
     expect(cfg.skin_tone).toBe('medium_dark');
-    expect(cfg.avatar_image_url).toBe('https://example.com/av.jpg');
   });
 
   it('sends avatar_config: null when avatarConfig is explicitly null', () => {

--- a/misfitai-mobile/src/__tests__/api.test.ts
+++ b/misfitai-mobile/src/__tests__/api.test.ts
@@ -2,6 +2,7 @@ import {
   ApiError,
   isApiError,
   getApiErrorMessage,
+  profileUpdateToApiPayload,
   API_BASE_URL,
 } from '../api';
 
@@ -149,5 +150,94 @@ describe('searchGarmentImages (mock mode)', () => {
     const { searchGarmentImages } = require('../api');
     const results = await searchGarmentImages('test-user', '');
     expect(results).toEqual([]);
+  });
+});
+
+// ------------------------------------------------------------------
+// getUserProfile (mock mode)
+// ------------------------------------------------------------------
+
+describe('getUserProfile (mock mode)', () => {
+  it('returns null for an unknown user id', async () => {
+    const { getUserProfile } = require('../api');
+    const result = await getUserProfile('unknown-user');
+    // Mock mode has no stored data — should return null.
+    expect(result).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------------
+// updateUserProfile (mock mode)
+// ------------------------------------------------------------------
+
+describe('updateUserProfile (mock mode)', () => {
+  it('returns a UserProfile shaped object', async () => {
+    const { updateUserProfile } = require('../api');
+    const result = await updateUserProfile('test-user', { gender: 'female' });
+    expect(result).toHaveProperty('userId');
+    expect(result).toHaveProperty('favoriteColors');
+    expect(Array.isArray(result.favoriteColors)).toBe(true);
+  });
+});
+
+// ------------------------------------------------------------------
+// profileUpdateToApiPayload — camelCase → snake_case mapping
+// ------------------------------------------------------------------
+
+describe('profileUpdateToApiPayload', () => {
+  it('maps camelCase to snake_case', () => {
+    const payload = profileUpdateToApiPayload({
+      skinTone: 'medium',
+      colorTone: 'warm',
+      favoriteColors: ['blue'],
+      avoidedColors: ['red'],
+      shoeSize: '42',
+      topSize: 'M',
+      bottomSize: 'L',
+    });
+    expect(payload.skin_tone).toBe('medium');
+    expect(payload.color_tone).toBe('warm');
+    expect(payload.favorite_colors).toEqual(['blue']);
+    expect(payload.avoided_colors).toEqual(['red']);
+    expect(payload.shoe_size).toBe('42');
+    expect(payload.top_size).toBe('M');
+    expect(payload.bottom_size).toBe('L');
+  });
+
+  it('omits keys not provided', () => {
+    const payload = profileUpdateToApiPayload({ gender: 'male' });
+    expect(payload.gender).toBe('male');
+    expect('skin_tone' in payload).toBe(false);
+    expect('avatar_config' in payload).toBe(false);
+  });
+
+  it('serialises avatarConfig object to snake_case keys', () => {
+    const payload = profileUpdateToApiPayload({
+      avatarConfig: {
+        hairStyle: 'long_straight',
+        hairColor: 'black',
+        bodyType: 'slim',
+        skinTone: 'medium_dark',
+        avatarImageUrl: 'https://example.com/av.jpg',
+      },
+    });
+    const cfg = payload.avatar_config as Record<string, unknown>;
+    expect(cfg).not.toBeNull();
+    expect(cfg.hair_style).toBe('long_straight');
+    expect(cfg.hair_color).toBe('black');
+    expect(cfg.body_type).toBe('slim');
+    expect(cfg.skin_tone).toBe('medium_dark');
+    expect(cfg.avatar_image_url).toBe('https://example.com/av.jpg');
+  });
+
+  it('sends avatar_config: null when avatarConfig is explicitly null', () => {
+    const payload = profileUpdateToApiPayload({ avatarConfig: null });
+    expect('avatar_config' in payload).toBe(true);
+    expect(payload.avatar_config).toBeNull();
+  });
+
+  it('does not include avatar_config when avatarConfig is undefined', () => {
+    const payload = profileUpdateToApiPayload({ gender: 'other' });
+    expect('avatar_config' in payload).toBe(false);
   });
 });

--- a/misfitai-mobile/src/api.ts
+++ b/misfitai-mobile/src/api.ts
@@ -1118,7 +1118,7 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
   }
 }
 
-function profileUpdateToApiPayload(data: UserProfileUpdate): Record<string, unknown> {
+export function profileUpdateToApiPayload(data: UserProfileUpdate): Record<string, unknown> {
   const payload: Record<string, unknown> = {};
   if (data.gender !== undefined) payload.gender = data.gender;
   if (data.birthday !== undefined) payload.birthday = data.birthday;
@@ -1129,14 +1129,20 @@ function profileUpdateToApiPayload(data: UserProfileUpdate): Record<string, unkn
   if (data.shoeSize !== undefined) payload.shoe_size = data.shoeSize;
   if (data.topSize !== undefined) payload.top_size = data.topSize;
   if (data.bottomSize !== undefined) payload.bottom_size = data.bottomSize;
-  if (data.avatarConfig !== undefined && data.avatarConfig !== null) {
-    const av: AvatarConfig = data.avatarConfig;
-    payload.avatar_config = {
-      hair_style: av.hairStyle ?? null,
-      hair_color: av.hairColor ?? null,
-      body_type: av.bodyType ?? null,
-      skin_tone: av.skinTone ?? null,
-    };
+  if (data.avatarConfig !== undefined) {
+    if (data.avatarConfig === null) {
+      // Explicit null: tell the server to clear the stored avatar config.
+      payload.avatar_config = null;
+    } else {
+      const av: AvatarConfig = data.avatarConfig;
+      payload.avatar_config = {
+        hair_style: av.hairStyle ?? null,
+        hair_color: av.hairColor ?? null,
+        body_type: av.bodyType ?? null,
+        skin_tone: av.skinTone ?? null,
+        avatar_image_url: av.avatarImageUrl ?? null,
+      };
+    }
   }
   return payload;
 }

--- a/misfitai-mobile/src/api.ts
+++ b/misfitai-mobile/src/api.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 import { dayLabels, dayOrder, eventTypeLabels } from './constants';
 import type {
+  AvatarConfig,
   BodyMeasurements,
   CalendarEvent,
   DayOfWeek,
@@ -11,6 +12,8 @@ import type {
   GarmentFormality,
   GarmentGender,
   GarmentSeasonality,
+  UserProfile,
+  UserProfileUpdate,
 } from './types';
 
 const DEFAULT_API_BASE_URL =
@@ -1052,6 +1055,113 @@ export async function saveMeasurements(
     }
   );
   return mapMeasurements(response);
+}
+
+// ---------------------------------------------------------------------------
+// User profile (style preferences, sizes, avatar)
+// ---------------------------------------------------------------------------
+
+interface ProfileApiResponse {
+  user_id: string;
+  gender?: string | null;
+  birthday?: string | null;
+  skin_tone?: string | null;
+  color_tone?: string | null;
+  favorite_colors?: string[];
+  avoided_colors?: string[];
+  shoe_size?: string | null;
+  top_size?: string | null;
+  bottom_size?: string | null;
+  avatar_config?: {
+    hair_style?: string | null;
+    hair_color?: string | null;
+    body_type?: string | null;
+    skin_tone?: string | null;
+  } | null;
+  updated_at?: string;
+}
+
+function mapUserProfile(r: ProfileApiResponse): UserProfile {
+  return {
+    userId: r.user_id,
+    gender: (r.gender as UserProfile['gender']) ?? null,
+    birthday: r.birthday ?? null,
+    skinTone: (r.skin_tone as UserProfile['skinTone']) ?? null,
+    colorTone: (r.color_tone as UserProfile['colorTone']) ?? null,
+    favoriteColors: r.favorite_colors ?? [],
+    avoidedColors: r.avoided_colors ?? [],
+    shoeSize: r.shoe_size ?? null,
+    topSize: r.top_size ?? null,
+    bottomSize: r.bottom_size ?? null,
+    avatarConfig: r.avatar_config
+      ? {
+          hairStyle: r.avatar_config.hair_style ?? null,
+          hairColor: r.avatar_config.hair_color ?? null,
+          bodyType: r.avatar_config.body_type ?? null,
+          skinTone: r.avatar_config.skin_tone ?? null,
+        }
+      : null,
+    updatedAt: r.updated_at,
+  };
+}
+
+/** Fetch extended style profile for *userId*. Returns ``null`` when not yet created. */
+export async function getUserProfile(userId: string): Promise<UserProfile | null> {
+  if (USE_MOCK_API) return null;
+  try {
+    const response = await requestJson<ProfileApiResponse | null>(
+      `/users/${encodeURIComponent(userId)}/profile`
+    );
+    return response ? mapUserProfile(response) : null;
+  } catch {
+    return null;
+  }
+}
+
+function profileUpdateToApiPayload(data: UserProfileUpdate): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (data.gender !== undefined) payload.gender = data.gender;
+  if (data.birthday !== undefined) payload.birthday = data.birthday;
+  if (data.skinTone !== undefined) payload.skin_tone = data.skinTone;
+  if (data.colorTone !== undefined) payload.color_tone = data.colorTone;
+  if (data.favoriteColors !== undefined) payload.favorite_colors = data.favoriteColors;
+  if (data.avoidedColors !== undefined) payload.avoided_colors = data.avoidedColors;
+  if (data.shoeSize !== undefined) payload.shoe_size = data.shoeSize;
+  if (data.topSize !== undefined) payload.top_size = data.topSize;
+  if (data.bottomSize !== undefined) payload.bottom_size = data.bottomSize;
+  if (data.avatarConfig !== undefined && data.avatarConfig !== null) {
+    const av: AvatarConfig = data.avatarConfig;
+    payload.avatar_config = {
+      hair_style: av.hairStyle ?? null,
+      hair_color: av.hairColor ?? null,
+      body_type: av.bodyType ?? null,
+      skin_tone: av.skinTone ?? null,
+    };
+  }
+  return payload;
+}
+
+/** Create or partially update the style profile for *userId*. */
+export async function updateUserProfile(
+  userId: string,
+  data: UserProfileUpdate
+): Promise<UserProfile> {
+  if (USE_MOCK_API) {
+    return {
+      userId,
+      favoriteColors: data.favoriteColors ?? [],
+      avoidedColors: data.avoidedColors ?? [],
+      ...data,
+    };
+  }
+  const response = await requestJson<ProfileApiResponse>(
+    `/users/${encodeURIComponent(userId)}/profile`,
+    {
+      method: 'PUT',
+      body: JSON.stringify(profileUpdateToApiPayload(data)),
+    }
+  );
+  return mapUserProfile(response);
 }
 
 // ---------------------------------------------------------------------------

--- a/misfitai-mobile/src/api.ts
+++ b/misfitai-mobile/src/api.ts
@@ -1140,7 +1140,6 @@ export function profileUpdateToApiPayload(data: UserProfileUpdate): Record<strin
         hair_color: av.hairColor ?? null,
         body_type: av.bodyType ?? null,
         skin_tone: av.skinTone ?? null,
-        avatar_image_url: av.avatarImageUrl ?? null,
       };
     }
   }

--- a/misfitai-mobile/src/types.ts
+++ b/misfitai-mobile/src/types.ts
@@ -81,3 +81,53 @@ export interface DayRecommendation {
   outfit: Outfit;
   explanation: string;
 }
+
+// ---------------------------------------------------------------------------
+// User profile (style preferences, sizes, avatar)
+// ---------------------------------------------------------------------------
+
+export interface AvatarConfig {
+  hairStyle?: string | null;
+  hairColor?: string | null;
+  bodyType?: string | null;
+  skinTone?: string | null;
+}
+
+export type ColorTone = 'warm' | 'cool' | 'neutral';
+
+export type SkinTone =
+  | 'very_light'
+  | 'light'
+  | 'medium_light'
+  | 'medium'
+  | 'medium_dark'
+  | 'dark';
+
+export interface UserProfile {
+  userId: string;
+  gender?: 'male' | 'female' | 'other' | null;
+  birthday?: string | null;
+  skinTone?: SkinTone | null;
+  colorTone?: ColorTone | null;
+  favoriteColors: string[];
+  avoidedColors: string[];
+  shoeSize?: string | null;
+  topSize?: string | null;
+  bottomSize?: string | null;
+  avatarConfig?: AvatarConfig | null;
+  updatedAt?: string;
+}
+
+/** Partial update payload for PUT /users/{userId}/profile */
+export interface UserProfileUpdate {
+  gender?: 'male' | 'female' | 'other' | null;
+  birthday?: string | null;
+  skinTone?: SkinTone | null;
+  colorTone?: ColorTone | null;
+  favoriteColors?: string[];
+  avoidedColors?: string[];
+  shoeSize?: string | null;
+  topSize?: string | null;
+  bottomSize?: string | null;
+  avatarConfig?: AvatarConfig | null;
+}

--- a/scripts/sql/user_profiles.sql
+++ b/scripts/sql/user_profiles.sql
@@ -1,0 +1,32 @@
+-- Extended user profile: style preferences, sizes, color tone, and avatar config.
+-- Run in Supabase SQL editor once (after app_users.sql is applied).
+
+create table if not exists public.user_profiles (
+  user_id         text primary key,
+  gender          text,
+  birthday        text,
+  skin_tone       text,
+  color_tone      text,     -- 'warm' | 'cool' | 'neutral'
+  favorite_colors text[],   -- array of colour names / hex codes chosen by user
+  avoided_colors  text[],   -- array of colour names / hex codes the user wants excluded
+  shoe_size       text,
+  top_size        text,
+  bottom_size     text,
+  avatar_config   jsonb,    -- {hair_style, hair_color, body_type, skin_tone}
+  updated_at      timestamptz not null default now()
+);
+
+comment on table public.user_profiles is
+  'Extended style profile: measurements are in user_measurements; identity in app_users.';
+
+comment on column public.user_profiles.color_tone is
+  'Broad colour temperature preference: warm, cool, or neutral.';
+
+comment on column public.user_profiles.favorite_colors is
+  'Colours the user wants to see prioritised in recommendations.';
+
+comment on column public.user_profiles.avoided_colors is
+  'Colours the user wants de-prioritised or excluded from recommendations.';
+
+comment on column public.user_profiles.avatar_config is
+  'JSON blob for the Bitmoji-style avatar: hair_style, hair_color, body_type, skin_tone.';


### PR DESCRIPTION
Adds a prototype “Profile” tab with an extended user style profile (colors/sizes/avatar), persists it via new backend endpoints + Supabase table, and feeds those preferences into the recommendation engine.

## Changes:

- Add user_profiles Supabase table and backend GET/PUT profile endpoints.
- Add mobile profile types + API calls, a multi-step profile setup wizard, and a new Profile tab/screen.
- Incorporate profile color preferences into garment selection/scoring in recommendations.

<img width="2970" height="1416" alt="image" src="https://github.com/user-attachments/assets/77f99880-640e-4e82-ab05-22e2dc394571" />
<img width="2970" height="1554" alt="image" src="https://github.com/user-attachments/assets/95645b58-7200-482a-b50c-faf0c117a98f" />
<img width="2970" height="956" alt="image" src="https://github.com/user-attachments/assets/2360776b-ec8c-4ef3-99ce-c19fc899a502" />
<img width="2970" height="956" alt="image" src="https://github.com/user-attachments/assets/6410f6ee-c5b6-4d17-87f7-269f5abc649c" />
