### PR TITLE
Shop-to-complete wardrobe: gap detection, product suggestions, and purchase flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,13 @@ LOCAL_ASSET_BASE_URL=http://127.0.0.1:8000
 # No spaces around = (required for shell sourcing and for python-dotenv)
 SERPAPI_KEY=<put_yours_here>
 
+# Shop suggestions (Google Shopping via SerpAPI — same SERPAPI_KEY as garment image search).
+# SHOP_PRODUCT_PROVIDER=serpapi   # serpapi | curated
+# SHOP_CACHE_TTL_SEC=3600
+# SHOP_GAP_LLM_RANK=false         # optional Gemini reorder of rule-based gaps (needs GOOGLE_CLOUD_PROJECT)
+# SHOP_AFFILIATE_TAG=             # optional query suffix appended to merchant URLs
+# SUPABASE_SHOP_EVENTS_TABLE=shop_engagement_events
+
 SUPABASE_URL=<>
 SUPABASE_SERVICE_KEY=<>
 SUPABASE_GARMENTS_BUCKET=garments

--- a/backend/db.py
+++ b/backend/db.py
@@ -79,6 +79,13 @@ def _profiles_table_name() -> str:
     return os.getenv("SUPABASE_PROFILES_TABLE", "user_profiles")
 
 
+def _shop_events_table() -> str:
+    return (os.getenv("SUPABASE_SHOP_EVENTS_TABLE") or "shop_engagement_events").strip() or "shop_engagement_events"
+
+
+_local_shop_events: dict[str, list[dict[str, Any]]] = {}
+
+
 def _signup_registry_table() -> str:
     return (os.getenv("SUPABASE_SIGNUPS_TABLE") or "analytics_registered_users").strip() or "analytics_registered_users"
 
@@ -733,6 +740,7 @@ def _row_to_user_profile(row: dict[str, Any]) -> UserProfile:
         color_tone=row.get("color_tone"),
         favorite_colors=_str_list("favorite_colors"),
         avoided_colors=_str_list("avoided_colors"),
+        favorite_brands=_str_list("favorite_brands"),
         shoe_size=row.get("shoe_size"),
         top_size=row.get("top_size"),
         bottom_size=row.get("bottom_size"),
@@ -848,3 +856,47 @@ def store_avatar_image(user_id: str, image_bytes: bytes) -> str:
     except Exception:
         logger.exception("store_avatar_image failed user_id=%s", user_id)
         raise
+
+
+# ---------------------------------------------------------------------------
+# Shop engagement (append-only analytics)
+# ---------------------------------------------------------------------------
+
+
+def insert_shop_engagement_event(
+    user_id: str,
+    gap_id: str,
+    event_type: str,
+    product_id: Optional[str] = None,
+) -> None:
+    """Record a shop funnel event. Failures are logged only."""
+    now = datetime.utcnow().isoformat()
+    gap_id = (gap_id or "").strip()[:128]
+    event_type = (event_type or "").strip()[:64]
+    product_id = (product_id or "").strip()[:128] or None
+    row: dict[str, Any] = {
+        "user_id": user_id,
+        "gap_id": gap_id,
+        "event_type": event_type,
+        "product_id": product_id,
+        "created_at": now,
+    }
+    if _use_local_store():
+        _local_shop_events.setdefault(user_id, []).append(row)
+        logger.info(
+            "shop_event local user_id=%s gap_id=%s type=%s",
+            user_id,
+            gap_id,
+            event_type,
+        )
+        return
+    try:
+        get_supabase_client().table(_shop_events_table()).insert(row).execute()
+        logger.info(
+            "shop_event supabase user_id=%s gap_id=%s type=%s",
+            user_id,
+            gap_id,
+            event_type,
+        )
+    except Exception:
+        logger.exception("insert_shop_engagement_event failed user_id=%s", user_id)

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -267,3 +267,46 @@ async def generate_outfit_explanation(
             exc,
         )
         return _FALLBACK_TEMPLATE.format(day=day, event_type=event_label)
+
+
+_RANK_GAPS_PROMPT = """You rank wardrobe "gaps" (missing pieces) for a shopping assistant.
+Input is JSON with inventory counts, calendar week_weights, and a gaps list (each has gap_id, title, reason, priority).
+Return ONLY a JSON array of gap_id strings: best order for impact, using every gap_id from the input exactly once.
+No markdown, no explanation."""
+
+
+async def rank_shop_gap_ids(structured_json: str) -> Optional[list[str]]:
+    """
+    Optionally reorder gap ids via Gemini when ``SHOP_GAP_LLM_RANK`` is truthy.
+    Returns ``None`` when disabled, client unavailable, or parsing fails.
+    """
+    flag = os.getenv("SHOP_GAP_LLM_RANK", "").strip().lower()
+    if flag not in ("1", "true", "yes", "on"):
+        return None
+    client = _gemini_client()
+    if client is None:
+        return None
+    try:
+        response = await asyncio.to_thread(
+            client.models.generate_content,
+            model=_model,
+            contents=[
+                types.Part.from_text(text=_RANK_GAPS_PROMPT),
+                types.Part.from_text(text=structured_json),
+            ],
+            config=types.GenerateContentConfig(max_output_tokens=256, temperature=0.2),
+        )
+        raw = (response.text or "").strip()
+        if raw.startswith("```"):
+            raw = raw.strip("`")
+            if raw.lower().startswith("json"):
+                raw = raw[4:].lstrip()
+        import json
+
+        data = json.loads(raw)
+        if not isinstance(data, list):
+            return None
+        return [str(x) for x in data]
+    except Exception as exc:
+        logger.warning("rank_shop_gap_ids failed: %s", exc)
+        return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ from .models import (
     MediaType,
     WeekEvent,
 )
-from .routers import analytics_router, auth_router, recommendations, weather_router, calendar_router, profile_router, avatar_router
+from .routers import analytics_router, auth_router, recommendations, weather_router, calendar_router, profile_router, avatar_router, shop_router
 from .routers.analytics_router import public_metrics_router
 from .storage import get_wardrobe, get_week_events as _storage_get_week_events, store_week_events
 
@@ -50,7 +50,7 @@ app = FastAPI(title="AI Wardrobe Planner API", version="0.1.0")
 # Example: ALLOWED_ORIGINS="https://app.misfitai.com,https://staging.misfitai.com"
 _raw_origins = os.getenv(
     "ALLOWED_ORIGINS",
-    "http://localhost:8081,http://127.0.0.1:8081,http://localhost:3000",
+    "http://localhost:8081,http://127.0.0.1:8081,http://[::1]:8081,http://localhost:3000,http://localhost:19006,http://127.0.0.1:19006",
 )
 _allowed_origins: list[str] = [o.strip() for o in _raw_origins.split(",") if o.strip()]
 
@@ -78,6 +78,7 @@ app.include_router(analytics_router.router)
 app.include_router(public_metrics_router)
 app.include_router(profile_router.router)
 app.include_router(avatar_router.router)
+app.include_router(shop_router.router)
 
 _local_assets_dir = Path(os.getenv("LOCAL_GARMENTS_DIR", "outputs/local_garments"))
 _local_assets_dir.mkdir(parents=True, exist_ok=True)
@@ -115,6 +116,7 @@ class AddGarmentRequest(BaseModel):
     seasonality: Optional[GarmentSeasonality] = None
     primary_image_url: HttpUrl
     gender: Optional[GarmentGender] = None
+    brand: Optional[str] = None
 
 
 class SearchGarmentRequest(BaseModel):
@@ -275,6 +277,7 @@ def add_wardrobe_item(user_id: str, request: AddGarmentRequest) -> GarmentItem:
         formality=formality,
         seasonality=seasonality,
         gender=request.gender,
+        brand=(request.brand or "").strip() or None,
         tags=tags,
         created_at=now,
         updated_at=now,

--- a/backend/models.py
+++ b/backend/models.py
@@ -199,6 +199,9 @@ class UserProfile(BaseModel):
     avoided_colors: List[str] = []
     """Colour names / hex codes the user wants de-prioritised or excluded."""
 
+    favorite_brands: List[str] = []
+    """Retail brands the user wants prioritised in shop search queries."""
+
     # --- Sizes ---
     shoe_size: Optional[str] = None
     top_size: Optional[str] = None
@@ -294,3 +297,60 @@ class WeekRecommendationResponse(BaseModel):
 
     user_id: str
     recommendations: List[DayOutfitSuggestion]
+
+
+# ---------------------------------------------------------------------------
+# Shop — wardrobe gaps & product options
+# ---------------------------------------------------------------------------
+
+
+class ShopProductOption(BaseModel):
+    """A single purchasable option surfaced for a wardrobe gap."""
+
+    id: str
+    title: str
+    brand: Optional[str] = None
+    price_display: Optional[str] = None
+    image_url: str
+    merchant_url: str
+    affiliate_url: Optional[str] = None
+
+
+class WardrobeGapSuggestion(BaseModel):
+    """One high-impact gap with zero or more product options."""
+
+    gap_id: str
+    title: str
+    reason: str
+    target_category: GarmentCategory
+    target_formality: Optional[GarmentFormality] = None
+    suggested_name: str
+    products: List[ShopProductOption] = []
+
+
+class ShopSuggestionsResponse(BaseModel):
+    user_id: str
+    gaps: List[WardrobeGapSuggestion]
+
+
+class ShopEventRequest(BaseModel):
+    gap_id: str
+    event_type: str
+    """One of ``impression``, ``click``, ``dismiss``, ``add_to_wardrobe``."""
+    product_id: Optional[str] = None
+
+
+class ShopMarkPurchasedRequest(BaseModel):
+    """Create a wardrobe item from a shop product (same fields as manual add)."""
+
+    gap_id: str
+    suggested_name: str
+    title: str
+    primary_image_url: HttpUrl
+    category: GarmentCategory
+    formality: Optional[GarmentFormality] = None
+    seasonality: Optional[GarmentSeasonality] = None
+    color: Optional[str] = None
+    brand: Optional[str] = None
+    product_id: Optional[str] = None
+    merchant_url: Optional[str] = None

--- a/backend/routers/profile_router.py
+++ b/backend/routers/profile_router.py
@@ -17,6 +17,23 @@ from ..models import AvatarConfig, UserProfile
 
 router = APIRouter(prefix="/users", tags=["profile"])
 
+_MAX_FAVORITE_BRANDS = 12
+_MAX_BRAND_LEN = 60
+
+
+def _sanitize_favorite_brands(raw: Optional[List[str]]) -> Optional[List[str]]:
+    if raw is None:
+        return None
+    out: List[str] = []
+    for x in raw[:_MAX_FAVORITE_BRANDS]:
+        s = (str(x) if x is not None else "").strip()
+        if not s:
+            continue
+        if len(s) > _MAX_BRAND_LEN:
+            s = s[:_MAX_BRAND_LEN]
+        out.append(s)
+    return out
+
 
 # ---------------------------------------------------------------------------
 # Request / response bodies
@@ -50,6 +67,7 @@ class UserProfileBody(BaseModel):
     color_tone: Optional[str] = None
     favorite_colors: Optional[List[str]] = None
     avoided_colors: Optional[List[str]] = None
+    favorite_brands: Optional[List[str]] = None
     shoe_size: Optional[str] = None
     top_size: Optional[str] = None
     bottom_size: Optional[str] = None
@@ -101,6 +119,9 @@ async def update_profile(user_id: str, body: UserProfileBody) -> UserProfile:
     ):
         if field in body.model_fields_set:
             data[field] = getattr(body, field)
+
+    if "favorite_brands" in body.model_fields_set:
+        data["favorite_brands"] = _sanitize_favorite_brands(body.favorite_brands)
 
     # avatar_config: null clears it; a non-null object merges only keys that appear in the body.
     if "avatar_config" in body.model_fields_set:

--- a/backend/routers/shop_router.py
+++ b/backend/routers/shop_router.py
@@ -1,0 +1,137 @@
+"""
+Shop to Complete Your Wardrobe — gap detection + product options + engagement.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..db import get_wardrobe, get_user_profile, insert_garment, insert_shop_engagement_event
+from ..llm import rank_shop_gap_ids
+from ..models import (
+    GarmentItem,
+    GarmentFormality,
+    GarmentSeasonality,
+    ShopEventRequest,
+    ShopMarkPurchasedRequest,
+    ShopSuggestionsResponse,
+    WardrobeGapSuggestion,
+    build_garment_tags,
+)
+from ..shop_products import search_products_cached
+from ..storage import get_week_events
+from ..wardrobe_gaps import (
+    DetectedGap,
+    build_shop_query,
+    detect_gaps,
+    gaps_to_llm_payload,
+    infer_preferred_brands,
+    wardrobe_inventory_summary,
+    week_event_weights,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/users", tags=["shop"])
+
+_ALLOWED_EVENTS = frozenset({"impression", "click", "dismiss", "add_to_wardrobe"})
+
+
+class ShopEventAck(BaseModel):
+    ok: bool = True
+
+
+def _reorder_gaps(
+    gaps: list[DetectedGap],
+    ordered_ids: list[str] | None,
+) -> list[DetectedGap]:
+    if not ordered_ids:
+        return gaps
+    id_set = {g.gap_id for g in gaps}
+    merged: list[str] = []
+    for i in ordered_ids:
+        if i in id_set and i not in merged:
+            merged.append(i)
+    for g in gaps:
+        if g.gap_id not in merged:
+            merged.append(g.gap_id)
+    if set(merged) != id_set:
+        logger.warning("shop_llm_rank ignored: invalid id set")
+        return gaps
+    m = {g.gap_id: g for g in gaps}
+    return [m[i] for i in merged]
+
+
+@router.get("/{user_id}/shop/suggestions", response_model=ShopSuggestionsResponse)
+async def get_shop_suggestions(user_id: str) -> ShopSuggestionsResponse:
+    wardrobe = get_wardrobe(user_id)
+    profile = get_user_profile(user_id)
+    summary = wardrobe_inventory_summary(wardrobe)
+    weights = week_event_weights(get_week_events(user_id))
+    gaps = detect_gaps(summary, weights)
+
+    payload = gaps_to_llm_payload(summary, weights, gaps)
+    llm_order = await rank_shop_gap_ids(payload)
+    gaps = _reorder_gaps(gaps, llm_order)
+
+    inferred = infer_preferred_brands(summary)
+    out: list[WardrobeGapSuggestion] = []
+    for g in gaps[:8]:
+        q = build_shop_query(g, profile, inferred)
+        products = search_products_cached(g.gap_id, q, 4)
+        out.append(
+            WardrobeGapSuggestion(
+                gap_id=g.gap_id,
+                title=g.title,
+                reason=g.reason,
+                target_category=g.target_category,
+                target_formality=g.target_formality,
+                suggested_name=g.suggested_name,
+                products=products,
+            )
+        )
+    return ShopSuggestionsResponse(user_id=user_id, gaps=out)
+
+
+@router.post("/{user_id}/shop/events", response_model=ShopEventAck)
+async def post_shop_event(user_id: str, body: ShopEventRequest) -> ShopEventAck:
+    et = (body.event_type or "").strip().lower()
+    if et not in _ALLOWED_EVENTS:
+        raise HTTPException(status_code=400, detail="invalid event_type")
+    insert_shop_engagement_event(user_id, body.gap_id, et, body.product_id)
+    return ShopEventAck()
+
+
+@router.post("/{user_id}/shop/mark-purchased", response_model=GarmentItem)
+async def mark_shop_purchased(user_id: str, body: ShopMarkPurchasedRequest) -> GarmentItem:
+    now = datetime.utcnow()
+    formality = body.formality or GarmentFormality.CASUAL
+    seasonality = body.seasonality or GarmentSeasonality.ALL_SEASON
+    tags = build_garment_tags(body.category, formality, seasonality)
+    sub = (body.suggested_name or body.title or "item").strip()[:200]
+    garment = GarmentItem(
+        id=str(uuid4()),
+        user_id=user_id,
+        primary_image_url=body.primary_image_url,
+        category=body.category,
+        sub_category=sub,
+        color_primary=body.color,
+        formality=formality,
+        seasonality=seasonality,
+        brand=(body.brand or "").strip() or None,
+        tags=tags,
+        created_at=now,
+        updated_at=now,
+    )
+    insert_shop_engagement_event(
+        user_id,
+        body.gap_id,
+        "add_to_wardrobe",
+        body.product_id,
+    )
+    return insert_garment(garment)

--- a/backend/shop_products.py
+++ b/backend/shop_products.py
@@ -1,0 +1,318 @@
+"""
+Product search for shop suggestions: SerpAPI Google Shopping, curated fallback, TTL cache.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+
+import httpx
+
+from .models import ShopProductOption
+
+logger = logging.getLogger(__name__)
+
+_SHOP_CACHE: dict[str, tuple[float, list[ShopProductOption]]] = {}
+
+
+def _cache_ttl_sec() -> float:
+    try:
+        return max(60.0, float(os.getenv("SHOP_CACHE_TTL_SEC", "3600")))
+    except ValueError:
+        return 3600.0
+
+
+def _cache_key(query: str, limit: int) -> str:
+    raw = f"{query.strip().lower()}|{limit}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:32]
+
+
+def cache_get(query: str, limit: int) -> Optional[list[ShopProductOption]]:
+    key = _cache_key(query, limit)
+    entry = _SHOP_CACHE.get(key)
+    if not entry:
+        logger.debug("shop_cache miss key=%s", key)
+        return None
+    expires_at, products = entry
+    if time.monotonic() > expires_at:
+        del _SHOP_CACHE[key]
+        logger.debug("shop_cache expired key=%s", key)
+        return None
+    logger.info("shop_cache hit key=%s products=%d", key, len(products))
+    return products
+
+
+def cache_set(query: str, limit: int, products: list[ShopProductOption]) -> None:
+    key = _cache_key(query, limit)
+    ttl = _cache_ttl_sec()
+    _SHOP_CACHE[key] = (time.monotonic() + ttl, products)
+
+
+def _placeholder_image_url(title: str) -> str:
+    """HTTPS placeholder so web clients never get mixed-content; short label for readability."""
+    label = (title or "Product").strip()[:36] or "Product"
+    safe = quote(label.replace("&", " "), safe=" ")
+    return f"https://placehold.co/320x320/eaeaea/1a1a1a/png?text={safe}"
+
+
+def _first_url(*candidates: object) -> str:
+    for c in candidates:
+        if c is None:
+            continue
+        if isinstance(c, str):
+            u = c.strip()
+            if u.startswith("//"):
+                u = "https:" + u
+            if u.startswith(("http://", "https://")):
+                return u
+        elif isinstance(c, list):
+            for item in c:
+                u = _first_url(item)
+                if u:
+                    return u
+        elif isinstance(c, dict):
+            u = _first_url(
+                c.get("link"),
+                c.get("url"),
+                c.get("src"),
+                c.get("thumbnail"),
+                c.get("original"),
+            )
+            if u:
+                return u
+    return ""
+
+
+def _extract_product_image_url(raw: dict[str, Any]) -> str:
+    """
+    SerpAPI shopping payloads vary: ``thumbnail``, ``serpapi_thumbnail``,
+    ``thumbnails[]``, ``serpapi_thumbnails[]``, nested ``image``, etc.
+    Prefer SerpApi-hosted URLs (often more reliable as img src than gstatic).
+    """
+    return _first_url(
+        raw.get("serpapi_thumbnail"),
+        raw.get("serpapi_thumbnails"),
+        raw.get("thumbnail"),
+        raw.get("thumbnails"),
+        raw.get("image"),
+        raw.get("img"),
+        raw.get("img_src"),
+        raw.get("images"),
+    )
+
+
+def append_affiliate_params(url: str) -> str:
+    suffix = (os.getenv("SHOP_AFFILIATE_QUERY_SUFFIX") or "").strip()
+    if not suffix or not url:
+        return url
+    parts = urlsplit(url)
+    q = dict(parse_qsl(parts.query, keep_blank_values=True))
+    for k, v in parse_qsl(suffix.lstrip("?"), keep_blank_values=True):
+        if k and k not in q:
+            q[k] = v
+    new_query = urlencode(q)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
+
+
+def normalize_shopping_result(raw: dict[str, Any], position: int) -> Optional[ShopProductOption]:
+    title = (raw.get("title") or raw.get("name") or "").strip()
+    link = (raw.get("link") or raw.get("product_link") or raw.get("tracking_link") or "").strip()
+    image_url = _extract_product_image_url(raw)
+    source = (raw.get("source") or raw.get("store") or raw.get("seller") or "").strip() or None
+    price = raw.get("extracted_price")
+    if price is None:
+        price = raw.get("price")
+    price_display = str(price).strip() if price not in (None, "") else None
+
+    if not title or not link:
+        return None
+    if not image_url:
+        image_url = _placeholder_image_url(title)
+
+    pid = str(raw.get("product_id") or raw.get("product_id_internal") or f"r{position}")
+    opt_id = hashlib.sha256(f"{link}|{title}|{pid}".encode()).hexdigest()[:16]
+
+    merchant_url = link
+    aff = append_affiliate_params(link)
+    affiliate_url: Optional[str] = aff if aff != merchant_url else None
+
+    return ShopProductOption(
+        id=opt_id,
+        title=title[:200],
+        brand=source,
+        price_display=price_display,
+        image_url=image_url[:2048],
+        merchant_url=merchant_url[:2048],
+        affiliate_url=affiliate_url[:2048] if affiliate_url else None,
+    )
+
+
+class ProductProvider(ABC):
+    @abstractmethod
+    def search(self, query: str, limit: int = 4) -> list[ShopProductOption]:
+        ...
+
+
+def _iter_shopping_dicts(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten SerpAPI ``shopping_results``, ``inline_shopping_results``, and categorized blocks."""
+    rows: list[dict[str, Any]] = []
+    for key in ("shopping_results", "inline_shopping_results"):
+        chunk = data.get(key)
+        if isinstance(chunk, list):
+            rows.extend(x for x in chunk if isinstance(x, dict))
+    categorized = data.get("categorized_shopping_results")
+    if isinstance(categorized, list):
+        for block in categorized:
+            if not isinstance(block, dict):
+                continue
+            inner = block.get("shopping_results")
+            if isinstance(inner, list):
+                rows.extend(x for x in inner if isinstance(x, dict))
+    return rows
+
+
+class SerpApiShoppingProvider(ProductProvider):
+    def search(self, query: str, limit: int = 4) -> list[ShopProductOption]:
+        api_key = (os.getenv("SERPAPI_KEY") or "").strip()
+        if not api_key:
+            logger.warning("shop_serpapi skipped: missing SERPAPI_KEY")
+            return []
+
+        fetch_n = min(40, max(limit * 5, 12))
+        params = {
+            "engine": "google_shopping",
+            "q": query,
+            "api_key": api_key,
+            "num": str(fetch_n),
+        }
+        t0 = time.perf_counter()
+        try:
+            with httpx.Client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+                resp = client.get("https://serpapi.com/search.json", params=params)
+        except httpx.RequestError as exc:
+            logger.exception("shop_serpapi request error: %s", type(exc).__name__)
+            return []
+
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        logger.info(
+            "shop_serpapi done status=%s elapsed_ms=%.1f query_len=%d",
+            resp.status_code,
+            elapsed_ms,
+            len(query),
+        )
+
+        if resp.status_code != 200:
+            logger.error("shop_serpapi bad status body_prefix=%s", (resp.text or "")[:200])
+            return []
+
+        try:
+            data = resp.json()
+        except json.JSONDecodeError:
+            logger.error("shop_serpapi invalid json")
+            return []
+
+        results = _iter_shopping_dicts(data)
+        if not results:
+            legacy = data.get("shopping_results") or data.get("organic_results") or []
+            if isinstance(legacy, list):
+                results = [x for x in legacy if isinstance(x, dict)]
+
+        scored: list[tuple[int, int, ShopProductOption]] = []
+        seen_link: set[str] = set()
+        for i, row in enumerate(results):
+            opt = normalize_shopping_result(row, i)
+            if not opt:
+                continue
+            key = opt.merchant_url.lower()
+            if key in seen_link:
+                continue
+            seen_link.add(key)
+            has_real = bool(_extract_product_image_url(row))
+            primary = 0 if has_real else 1
+            scored.append((primary, i, opt))
+
+        scored.sort(key=lambda t: (t[0], t[1]))
+        out = [t[2] for t in scored[:limit]]
+        return out
+
+
+class CuratedProductProvider(ProductProvider):
+    def __init__(self, path: Optional[Path] = None) -> None:
+        root = Path(__file__).resolve().parents[1]
+        self._path = path or Path(
+            os.getenv("SHOP_CURATED_JSON", str(root / "data" / "shop_curated_products.json"))
+        )
+
+    def _load_blob(self) -> dict[str, Any]:
+        if not self._path.is_file():
+            return {}
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def for_gap(self, gap_id: str, limit: int = 4) -> list[ShopProductOption]:
+        blob = self._load_blob()
+        rows = blob.get(gap_id) or []
+        if not isinstance(rows, list):
+            return []
+        out: list[ShopProductOption] = []
+        for i, row in enumerate(rows):
+            if len(out) >= limit:
+                break
+            if not isinstance(row, dict):
+                continue
+            opt = normalize_shopping_result(row, i)
+            if opt:
+                out.append(opt)
+        return out
+
+    def search(self, query: str, limit: int = 4) -> list[ShopProductOption]:
+        blob = self._load_blob()
+        if not blob:
+            return []
+        rows = blob.get("_default") or next(iter(blob.values()), [])
+        if not isinstance(rows, list):
+            return []
+        out: list[ShopProductOption] = []
+        for i, row in enumerate(rows):
+            if len(out) >= limit:
+                break
+            if not isinstance(row, dict):
+                continue
+            opt = normalize_shopping_result(row, i)
+            if opt:
+                out.append(opt)
+        return out
+
+
+def search_products_cached(gap_id: str, query: str, limit: int = 4) -> list[ShopProductOption]:
+    cache_query = f"{gap_id}|{query}"
+    cached = cache_get(cache_query, limit)
+    if cached is not None:
+        return cached
+    mode = (os.getenv("SHOP_PRODUCT_PROVIDER") or "serpapi").strip().lower()
+    curated = CuratedProductProvider()
+    products: list[ShopProductOption] = []
+    if mode == "curated":
+        products = curated.for_gap(gap_id, limit)
+        if not products:
+            products = curated.search(query, limit)
+    else:
+        products = SerpApiShoppingProvider().search(query, limit)
+        if not products:
+            products = curated.for_gap(gap_id, limit)
+        if not products:
+            products = curated.search(query, limit)
+    if products:
+        cache_set(cache_query, limit, products)
+    return products

--- a/backend/tests/test_integration/test_shop_routes.py
+++ b/backend/tests/test_integration/test_shop_routes.py
@@ -1,0 +1,69 @@
+"""Integration tests for shop suggestions and mark-purchased."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.models import WeekEvent
+from backend.storage import store_week_events
+
+
+@pytest.fixture(autouse=True)
+def _force_local_wardrobe_store(monkeypatch):
+    """Avoid Supabase when the developer has credentials in ``.env`` loaded by ``main``."""
+    monkeypatch.setattr("backend.db._use_local_store", lambda: True)
+
+
+@pytest.mark.usefixtures("_isolate_env")
+class TestShopSuggestions:
+    async def test_suggestions_returns_gaps_with_products(self, client):
+        store_week_events(
+            "shop-user",
+            [WeekEvent(day="monday", event_type="work_meeting")] * 3
+            + [WeekEvent(day="tuesday", event_type="casual")],
+        )
+        resp = await client.get("/users/shop-user/shop/suggestions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == "shop-user"
+        assert isinstance(data["gaps"], list)
+        assert len(data["gaps"]) >= 1
+        g0 = data["gaps"][0]
+        assert "gap_id" in g0
+        assert "products" in g0
+        assert isinstance(g0["products"], list)
+
+    async def test_shop_event_ok(self, client):
+        resp = await client.post(
+            "/users/shop-user/shop/events",
+            json={"gap_id": "neutral_shoes", "event_type": "click", "product_id": "abc"},
+        )
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+
+
+@pytest.mark.usefixtures("_isolate_env")
+class TestShopMarkPurchased:
+    async def test_creates_wardrobe_row(self, client):
+        resp = await client.post(
+            "/users/shop-user-2/shop/mark-purchased",
+            json={
+                "gap_id": "neutral_shoes",
+                "suggested_name": "White sneakers",
+                "title": "Example Sneaker",
+                "primary_image_url": "https://example.com/sneaker.jpg",
+                "category": "shoes",
+                "formality": "smart_casual",
+                "brand": "Example Co",
+            },
+        )
+        assert resp.status_code == 200
+        row = resp.json()
+        assert row["category"] == "shoes"
+        assert row["brand"] == "Example Co"
+
+        w = await client.get("/wardrobe/shop-user-2")
+        assert w.status_code == 200
+        items = w.json()
+        assert len(items) == 1
+        assert items[0]["sub_category"] == "White sneakers"

--- a/backend/tests/test_unit/test_recommendation.py
+++ b/backend/tests/test_unit/test_recommendation.py
@@ -304,3 +304,42 @@ class TestPickGarmentColourPriority:
         )
         assert result is not None
         assert result.id == "sized_clean"
+
+
+def _make_bottom(
+    id: str,
+    formality: GarmentFormality = GarmentFormality.CASUAL,
+) -> GarmentItem:
+    tags = build_garment_tags(GarmentCategory.BOTTOM, formality)
+    return GarmentItem(
+        id=id,
+        user_id="u1",
+        primary_image_url="https://x.com/b.jpg",
+        category=GarmentCategory.BOTTOM,
+        sub_category="pants",
+        formality=formality,
+        tags=tags,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+@pytest.mark.asyncio
+async def test_work_meeting_picks_business_top_after_mark_purchased_style_upgrade(monkeypatch):
+    """Simulates adding a business top (e.g. from Shop) so work days get a real top pick."""
+
+    async def fake_expl(*_a, **_k):
+        return "ok"
+
+    monkeypatch.setattr("backend.recommendation.generate_outfit_explanation", fake_expl)
+
+    casual = _make_top("t-casual", "blue", GarmentFormality.CASUAL)
+    bottom = _make_bottom("b1", GarmentFormality.CASUAL)
+    events = [WeekEvent(day="Monday", event_type="work_meeting")]
+
+    rec1 = await generate_week_recommendations([casual, bottom], events)
+    assert rec1[0].top_id is None
+
+    business = _make_top("t-biz", "white", GarmentFormality.BUSINESS)
+    rec2 = await generate_week_recommendations([casual, bottom, business], events)
+    assert rec2[0].top_id == "t-biz"

--- a/backend/tests/test_unit/test_shop_products.py
+++ b/backend/tests/test_unit/test_shop_products.py
@@ -1,0 +1,58 @@
+"""Unit tests for SerpAPI shopping provider parsing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from backend.shop_products import SerpApiShoppingProvider, normalize_shopping_result
+
+
+def test_normalize_shopping_result_minimal():
+    opt = normalize_shopping_result(
+        {
+            "title": "Test shoe",
+            "link": "https://merchant.example/p/1",
+            "thumbnail": "https://img.example/i.jpg",
+            "source": "Merchant",
+            "extracted_price": 99,
+        },
+        0,
+    )
+    assert opt is not None
+    assert opt.title == "Test shoe"
+    assert opt.merchant_url.startswith("https://merchant.example")
+    assert "99" in (opt.price_display or "")
+
+
+def test_serpapi_provider_parses_json(monkeypatch):
+    monkeypatch.setenv("SERPAPI_KEY", "fake-key-for-test")
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {
+        "shopping_results": [
+            {
+                "title": "Loafer",
+                "link": "https://shop.example/l",
+                "thumbnail": "https://shop.example/t.jpg",
+                "source": "Shop",
+                "extracted_price": "$120",
+            }
+        ]
+    }
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, _url, params=None):
+            return fake_resp
+
+    with patch("backend.shop_products.httpx.Client", return_value=FakeClient()):
+        out = SerpApiShoppingProvider().search("loafers", 4)
+
+    assert len(out) == 1
+    assert out[0].title == "Loafer"

--- a/backend/tests/test_unit/test_wardrobe_gaps.py
+++ b/backend/tests/test_unit/test_wardrobe_gaps.py
@@ -1,0 +1,100 @@
+"""Unit tests for wardrobe gap detection."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from backend.models import GarmentCategory, GarmentFormality, GarmentItem, GarmentSeasonality, WeekEvent, build_garment_tags
+from backend.wardrobe_gaps import (
+    build_shop_query,
+    detect_gaps,
+    wardrobe_inventory_summary,
+    week_event_weights,
+)
+
+
+def _item(
+    *,
+    category: GarmentCategory,
+    formality: GarmentFormality | None = None,
+    sub: str | None = None,
+    color: str | None = None,
+) -> GarmentItem:
+    now = datetime.utcnow()
+    tags = build_garment_tags(category, formality, GarmentSeasonality.ALL_SEASON)
+    return GarmentItem(
+        id=f"id-{category.value}-{sub or 'x'}",
+        user_id="u",
+        primary_image_url="https://example.com/i.jpg",
+        category=category,
+        sub_category=sub,
+        formality=formality,
+        seasonality=GarmentSeasonality.ALL_SEASON,
+        color_primary=color,
+        tags=tags,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestInventorySummary:
+    def test_counts_shoes_and_formal_shoes(self):
+        items = [
+            _item(category=GarmentCategory.SHOES, formality=GarmentFormality.BUSINESS, color="black"),
+            _item(category=GarmentCategory.SHOES, formality=GarmentFormality.CASUAL, color="red"),
+        ]
+        s = wardrobe_inventory_summary(items)
+        assert s.shoe_count == 2
+        assert s.formal_shoe_count == 1
+        assert s.neutral_shoe_count == 1
+
+
+class TestWeekEventWeights:
+    def test_normalizes_work_alias(self):
+        ev = [
+            WeekEvent(day="monday", event_type="work"),
+            WeekEvent(day="tuesday", event_type="casual"),
+        ]
+        w = week_event_weights(ev)
+        assert w.get("work_meeting") == 0.5
+
+
+class TestDetectGaps:
+    def test_outerwear_gap_when_none(self):
+        items = [
+            _item(category=GarmentCategory.TOP, formality=GarmentFormality.CASUAL),
+            _item(category=GarmentCategory.BOTTOM, formality=GarmentFormality.CASUAL),
+        ]
+        s = wardrobe_inventory_summary(items)
+        g = detect_gaps(s, {"work_meeting": 0.0})
+        ids = {x.gap_id for x in g}
+        assert "outerwear_layer" in ids
+
+    def test_formal_shoes_when_work_heavy(self):
+        items = [
+            _item(category=GarmentCategory.TOP, formality=GarmentFormality.CASUAL),
+            _item(category=GarmentCategory.BOTTOM, formality=GarmentFormality.CASUAL),
+            _item(category=GarmentCategory.SHOES, formality=GarmentFormality.CASUAL, color="red"),
+        ]
+        s = wardrobe_inventory_summary(items)
+        g = detect_gaps(s, {"work_meeting": 0.5})
+        ids = [x.gap_id for x in g]
+        assert "formal_shoes_work" in ids
+
+
+class TestBuildShopQuery:
+    def test_adds_gender_hint(self):
+        from backend.models import UserProfile
+
+        gap_list = detect_gaps(
+            wardrobe_inventory_summary([]),
+            {"work_meeting": 0.0},
+        )
+        gap = next(g for g in gap_list if g.gap_id == "neutral_shoes")
+        profile = UserProfile(
+            user_id="u",
+            gender="female",
+            updated_at=datetime.utcnow(),
+        )
+        q = build_shop_query(gap, profile, [])
+        assert "women" in q.lower()

--- a/backend/wardrobe_gaps.py
+++ b/backend/wardrobe_gaps.py
@@ -1,0 +1,386 @@
+"""
+Wardrobe gap taxonomy & detection (Shop to Complete Your Wardrobe).
+
+Gap types are aligned with ``recommendation.py``:
+
+- ``work_meeting`` uses formality chains ``formal``/``business`` then ``smart_casual``;
+  missing **business/formal shoes** or **work-appropriate layering** blocks polished outfits.
+- ``outerwear`` category fills cold-weather and layering needs.
+- **Neutral shoes** increase mix-and-match; detected when no versatile shoe colors exist.
+- **Accessories** (category ``accessory``) are suggested when the closet is large but
+  accessory count is very low (optional signal).
+
+Each gap maps to a :class:`GarmentCategory` and optional :class:`GarmentFormality` used
+when the user marks an item purchased (inserted as a :class:`GarmentItem`).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .models import (
+    GarmentCategory,
+    GarmentFormality,
+    GarmentItem,
+    UserProfile,
+)
+
+
+def _normalize_sub_category(value: str) -> str:
+    return re.sub(r"[\s\-]+", "_", value.strip().lower())
+
+
+_NEUTRAL_COLOR_TOKENS: frozenset[str] = frozenset(
+    {
+        "black", "navy", "white", "off", "ivory", "cream", "beige", "tan", "camel",
+        "brown", "grey", "gray", "charcoal", "taupe", "nude", "khaki", "bone",
+    }
+)
+
+_FORMAL_SHOE_FORMALITIES: frozenset[str] = frozenset({"business", "formal"})
+
+_LAYERING_SUBS: frozenset[str] = frozenset(
+    {"blazer", "cardigan", "sport_coat", "sport", "coat", "trench", "peacoat", "vest"}
+)
+
+
+@dataclass
+class WardrobeInventorySummary:
+    """Aggregated signals from the user's garments (non-hidden only)."""
+
+    total_items: int
+    by_category: dict[str, int]
+    shoe_count: int
+    outerwear_count: int
+    accessory_count: int
+    dress_count: int
+    formal_shoe_count: int
+    neutral_shoe_count: int
+    work_formal_top_count: int
+    layering_piece_count: int
+    brand_counts: dict[str, int]
+    has_neutral_bottom: bool
+
+
+def _visible(g: GarmentItem) -> bool:
+    return not g.hidden_from_recommendations
+
+
+def _color_tokens(item: GarmentItem) -> frozenset[str]:
+    words: set[str] = set()
+    for c in (item.color_primary, item.color_secondary):
+        if not c:
+            continue
+        words.update(re.split(r"[\s,/\-_]+", c.strip().lower()))
+    return frozenset(w for w in words if w)
+
+
+def _is_neutral_garment(item: GarmentItem) -> bool:
+    tokens = _color_tokens(item)
+    if not tokens:
+        return False
+    return bool(tokens & _NEUTRAL_COLOR_TOKENS)
+
+
+def wardrobe_inventory_summary(garments: list[GarmentItem]) -> WardrobeInventorySummary:
+    visible = [g for g in garments if _visible(g)]
+    by_cat: Counter[str] = Counter()
+    brand_counts: Counter[str] = Counter()
+    shoe_count = outerwear_count = accessory_count = dress_count = 0
+    formal_shoe_count = neutral_shoe_count = 0
+    work_formal_top_count = layering_piece_count = 0
+    neutral_bottom = False
+
+    for g in visible:
+        by_cat[g.category.value] += 1
+        if g.brand and g.brand.strip():
+            brand_counts[g.brand.strip().lower()] += 1
+
+        if g.category == GarmentCategory.SHOES:
+            shoe_count += 1
+            if g.formality and g.formality.value in _FORMAL_SHOE_FORMALITIES:
+                formal_shoe_count += 1
+            if _is_neutral_garment(g):
+                neutral_shoe_count += 1
+        elif g.category == GarmentCategory.OUTERWEAR:
+            outerwear_count += 1
+            sub = _normalize_sub_category(g.sub_category) if g.sub_category else ""
+            if sub in _LAYERING_SUBS or "blazer" in sub or "cardigan" in sub:
+                layering_piece_count += 1
+        elif g.category == GarmentCategory.ACCESSORY:
+            accessory_count += 1
+        elif g.category == GarmentCategory.DRESS:
+            dress_count += 1
+        elif g.category == GarmentCategory.TOP:
+            sub = _normalize_sub_category(g.sub_category) if g.sub_category else ""
+            if sub in _LAYERING_SUBS or sub == "blazer" or sub == "cardigan":
+                layering_piece_count += 1
+            if g.formality and g.formality.value in ("business", "formal", "smart_casual"):
+                work_formal_top_count += 1
+        elif g.category == GarmentCategory.BOTTOM:
+            if _is_neutral_garment(g):
+                neutral_bottom = True
+
+    return WardrobeInventorySummary(
+        total_items=len(visible),
+        by_category=dict(by_cat),
+        shoe_count=shoe_count,
+        outerwear_count=outerwear_count,
+        accessory_count=accessory_count,
+        dress_count=dress_count,
+        formal_shoe_count=formal_shoe_count,
+        neutral_shoe_count=neutral_shoe_count,
+        work_formal_top_count=work_formal_top_count,
+        layering_piece_count=layering_piece_count,
+        brand_counts=dict(brand_counts),
+        has_neutral_bottom=neutral_bottom,
+    )
+
+
+def infer_preferred_brands(summary: WardrobeInventorySummary, limit: int = 5) -> list[str]:
+    """Most common brands in the wardrobe (lowercased keys → title-case display)."""
+    pairs = sorted(summary.brand_counts.items(), key=lambda x: -x[1])[:limit]
+    out: list[str] = []
+    for key, _ in pairs:
+        out.append(key.title())
+    return out
+
+
+def week_event_weights(events: list[Any]) -> dict[str, float]:
+    """
+    Normalise stored week events to the same ``event_type`` vocabulary as
+    ``recommendation._FORMALITY_FALLBACK_CHAINS`` and return fractional weights.
+    """
+    if not events:
+        return {}
+    counts: Counter[str] = Counter()
+    for e in events:
+        raw = (getattr(e, "event_type", None) or "casual").strip().lower()
+        if raw in ("work", "office", "business"):
+            raw = "work_meeting"
+        if raw == "date":
+            raw = "date_night"
+        counts[raw] += 1
+    total = sum(counts.values())
+    if total <= 0:
+        return {}
+    return {k: v / total for k, v in counts.items()}
+
+
+@dataclass
+class DetectedGap:
+    gap_id: str
+    title: str
+    reason: str
+    target_category: GarmentCategory
+    target_formality: Optional[GarmentFormality]
+    suggested_name: str
+    query_seed: str
+    priority: int
+
+
+def detect_gaps(
+    summary: WardrobeInventorySummary,
+    weights: dict[str, float],
+) -> list[DetectedGap]:
+    """
+    Deterministic gap list. Higher *priority* sorts first (importance).
+    """
+    work_share = float(weights.get("work_meeting", 0.0))
+    gaps: list[DetectedGap] = []
+
+    # 1) Work-appropriate shoes when calendar is work-heavy
+    if work_share >= 0.2 and summary.formal_shoe_count == 0 and summary.shoe_count < 3:
+        gaps.append(
+            DetectedGap(
+                gap_id="formal_shoes_work",
+                title="Business-appropriate shoes",
+                reason="Your week includes several work meetings; formal or business shoes unlock polished outfits.",
+                target_category=GarmentCategory.SHOES,
+                target_formality=GarmentFormality.BUSINESS,
+                suggested_name="Leather loafers",
+                query_seed="leather loafers business casual",
+                priority=100,
+            )
+        )
+
+    # 2) Neutral versatile shoes
+    if summary.shoe_count == 0 or (summary.shoe_count > 0 and summary.neutral_shoe_count == 0):
+        gaps.append(
+            DetectedGap(
+                gap_id="neutral_shoes",
+                title="Neutral everyday shoes",
+                reason="Black, white, or tan shoes pair with more of what you already own.",
+                target_category=GarmentCategory.SHOES,
+                target_formality=GarmentFormality.SMART_CASUAL,
+                suggested_name="White sneakers",
+                query_seed="white leather sneakers minimal",
+                priority=90,
+            )
+        )
+
+    # 3) Outerwear
+    if summary.outerwear_count == 0:
+        gaps.append(
+            DetectedGap(
+                gap_id="outerwear_layer",
+                title="Versatile jacket or coat",
+                reason="A neutral outer layer extends outfits across seasons.",
+                target_category=GarmentCategory.OUTERWEAR,
+                target_formality=GarmentFormality.SMART_CASUAL,
+                suggested_name="Trench or wool coat",
+                query_seed="trench coat camel women classic",
+                priority=85,
+            )
+        )
+
+    # 4) Work layering (blazer / cardigan) when work-heavy and no layering pieces
+    if work_share >= 0.25 and summary.layering_piece_count == 0:
+        gaps.append(
+            DetectedGap(
+                gap_id="work_layering_blazer",
+                title="Blazer or structured layer",
+                reason="Meetings often need a smart layer over tops that are otherwise casual.",
+                target_category=GarmentCategory.TOP,
+                target_formality=GarmentFormality.BUSINESS,
+                suggested_name="Navy blazer",
+                query_seed="navy blazer women tailored",
+                priority=88,
+            )
+        )
+
+    # 5) Accessories for larger wardrobes
+    if summary.total_items >= 12 and summary.accessory_count < 2:
+        gaps.append(
+            DetectedGap(
+                gap_id="accessories_versatile",
+                title="Simple accessories",
+                reason="A few go-to accessories add polish without new outfits.",
+                target_category=GarmentCategory.ACCESSORY,
+                target_formality=GarmentFormality.SMART_CASUAL,
+                suggested_name="Gold hoop earrings",
+                query_seed="gold hoop earrings classic",
+                priority=55,
+            )
+        )
+
+    # 6) Neutral bottom if many colorful tops but no neutral pants
+    tops = summary.by_category.get("top", 0)
+    bottoms = summary.by_category.get("bottom", 0)
+    if tops >= 3 and bottoms >= 1 and not summary.has_neutral_bottom:
+        gaps.append(
+            DetectedGap(
+                gap_id="neutral_bottom",
+                title="Neutral pants or skirt",
+                reason="A black, navy, or beige bottom anchors loud tops and patterns.",
+                target_category=GarmentCategory.BOTTOM,
+                target_formality=GarmentFormality.SMART_CASUAL,
+                suggested_name="Black straight-leg pants",
+                query_seed="black straight leg pants women",
+                priority=70,
+            )
+        )
+
+    gaps.sort(key=lambda g: -g.priority)
+    # De-duplicate by gap_id while preserving order
+    seen: set[str] = set()
+    unique: list[DetectedGap] = []
+    for g in gaps:
+        if g.gap_id not in seen:
+            seen.add(g.gap_id)
+            unique.append(g)
+    return unique[:8]
+
+
+def _tokenize_prefs(colors: list[str]) -> frozenset[str]:
+    words: set[str] = set()
+    for c in colors:
+        if not c:
+            continue
+        words.update(re.split(r"[\s,/\-_#]+", c.strip().lower()))
+    return frozenset(w for w in words if len(w) > 1)
+
+
+def build_shop_query(
+    gap: DetectedGap,
+    profile: Optional[UserProfile],
+    inferred_brands: list[str],
+) -> str:
+    """Compose a shopping search string from gap + user preferences."""
+    parts: list[str] = [gap.query_seed]
+
+    gender_hint = ""
+    if profile and profile.gender:
+        g = profile.gender.lower()
+        if g == "female":
+            gender_hint = "women"
+        elif g == "male":
+            gender_hint = "men"
+    if gender_hint:
+        parts.append(gender_hint)
+
+    brands: list[str] = []
+    if profile and profile.favorite_brands:
+        brands.extend(profile.favorite_brands[:2])
+    brands.extend(inferred_brands[:1])
+    for b in brands:
+        b = (b or "").strip()
+        if b and b.lower() not in " ".join(parts).lower():
+            parts.append(b)
+            break
+
+    if profile and profile.favorite_colors:
+        fav = list(profile.favorite_colors)[:1]
+        avoid_words = _tokenize_prefs(profile.avoided_colors or [])
+        for c in fav:
+            tok = (c or "").strip()
+            if not tok:
+                continue
+            low = tok.lower()
+            if low in avoid_words:
+                continue
+            if low not in " ".join(parts).lower():
+                parts.append(tok)
+                break
+
+    q = " ".join(p for p in parts if p)
+    if profile and profile.avoided_colors:
+        # Soft exclusion: trim tokens that match avoided palette
+        avoid = _tokenize_prefs(profile.avoided_colors)
+        tokens = q.split()
+        tokens = [t for t in tokens if t.lower() not in avoid]
+        q = " ".join(tokens)
+    return q.strip()
+
+
+def gaps_to_llm_payload(
+    summary: WardrobeInventorySummary,
+    weights: dict[str, float],
+    gaps: list[DetectedGap],
+) -> str:
+    """Compact JSON-serialisable description for optional LLM ranker."""
+    import json
+
+    payload = {
+        "inventory": {
+            "total": summary.total_items,
+            "shoes": summary.shoe_count,
+            "formal_shoes": summary.formal_shoe_count,
+            "outerwear": summary.outerwear_count,
+            "accessories": summary.accessory_count,
+        },
+        "week_weights": weights,
+        "gaps": [
+            {
+                "gap_id": g.gap_id,
+                "title": g.title,
+                "reason": g.reason,
+                "priority": g.priority,
+            }
+            for g in gaps
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False)

--- a/data/shop_curated_products.json
+++ b/data/shop_curated_products.json
@@ -1,0 +1,63 @@
+{
+  "formal_shoes_work": [
+    {
+      "title": "Leather penny loafers",
+      "link": "https://example.com/products/loafers",
+      "thumbnail": "https://via.placeholder.com/320x320.png?text=Loafers",
+      "source": "Example Retailer",
+      "extracted_price": "$98"
+    },
+    {
+      "title": "Cap-toe Oxford shoes",
+      "link": "https://example.com/products/oxfords",
+      "thumbnail": "https://via.placeholder.com/320x320.png?text=Oxfords",
+      "source": "Example Retailer",
+      "extracted_price": "$145"
+    }
+  ],
+  "neutral_shoes": [
+    {
+      "title": "Minimal white sneakers",
+      "link": "https://example.com/products/white-sneakers",
+      "thumbnail": "https://via.placeholder.com/320x320.png?text=Sneakers",
+      "source": "Example Retailer",
+      "extracted_price": "$85"
+    }
+  ],
+  "outerwear_layer": [
+    {
+      "title": "Wool blend overcoat",
+      "link": "https://example.com/products/overcoat",
+      "thumbnail": "https://via.placeholder.com/320x320.png?text=Coat",
+      "source": "Example Retailer",
+      "extracted_price": "$198"
+    }
+  ],
+  "work_layering_blazer": [
+    {
+      "title": "Single-breasted navy blazer",
+      "link": "https://example.com/products/blazer",
+      "thumbnail": "https://via.placeholder.com/320x320.png?text=Blazer",
+      "source": "Example Retailer",
+      "extracted_price": "$128"
+    }
+  ],
+  "accessories_versatile": [
+    {
+      "title": "Medium gold hoop earrings",
+      "link": "https://example.com/products/hoops",
+      "thumbnail": "https://via.placeholder.com/320x320.png?text=Hoops",
+      "source": "Example Retailer",
+      "extracted_price": "$32"
+    }
+  ],
+  "neutral_bottom": [
+    {
+      "title": "High-rise black trousers",
+      "link": "https://example.com/products/trousers",
+      "thumbnail": "https://via.placeholder.com/320x320.png?text=Trousers",
+      "source": "Example Retailer",
+      "extracted_price": "$79"
+    }
+  ]
+}

--- a/misfitai-mobile/.env.example
+++ b/misfitai-mobile/.env.example
@@ -1,4 +1,6 @@
 EXPO_PUBLIC_USE_MOCK_API=false
+# iOS simulator + web: 127.0.0.1 is fine. Android emulator: the app rewrites 127.0.0.1/localhost → 10.0.2.2 automatically.
+# Physical phone: use your Mac/PC LAN IP, e.g. http://192.168.1.42:8000, and add that origin to backend ALLOWED_ORIGINS.
 EXPO_PUBLIC_API_BASE_URL=http://127.0.0.1:8000
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=<>
 # Google Analytics 4 (web only — Expo ``expo start --web``). Leave empty until the site is live.

--- a/misfitai-mobile/App.tsx
+++ b/misfitai-mobile/App.tsx
@@ -7,6 +7,7 @@ import { WardrobeScreen } from './src/WardrobeScreen';
 import { EventsScreen } from './src/EventsScreen';
 import { WeeklyPlanScreen } from './src/WeeklyPlanScreen';
 import { ProfileScreen } from './src/ProfileScreen';
+import { ShopToCompleteScreen } from './src/ShopToCompleteScreen';
 import { generateAvatar, registerSignupWithBackend, updateUserProfile, USE_MOCK_API } from './src/api';
 import { AtmosphereBackground } from './src/AtmosphereBackground';
 import { AuthScreen, type AuthMode, type AuthProvider, type UserProfile } from './src/AuthScreen';
@@ -39,7 +40,7 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
 
 const SESSION_STORAGE_KEY = '@misfitai/session';
 
-type Tab = 'wardrobe' | 'events' | 'plan' | 'profile';
+type Tab = 'wardrobe' | 'events' | 'plan' | 'profile' | 'shop';
 
 type Session = {
   provider: AuthProvider;
@@ -122,8 +123,14 @@ function AppContent({
 }) {
   const [tab, setTab] = useState<Tab>('wardrobe');
   const [tabHint, setTabHint] = useState<string | null>(null);
-  const { generateRecommendations, garments, isCalendarConnected, eventsByDay, recommendations } =
-    useAppState();
+  const {
+    generateRecommendations,
+    garments,
+    isCalendarConnected,
+    eventsByDay,
+    recommendations,
+    refreshWardrobe,
+  } = useAppState();
 
   const wardrobeStepComplete =
     garments.some((item) => item.category === 'top') &&
@@ -278,6 +285,13 @@ function AppContent({
             displayName={session.profile?.displayName}
           />
         ) : null}
+
+        {tab === 'shop' ? (
+          <ShopToCompleteScreen
+            userId={session.userId}
+            onWardrobeUpdated={refreshWardrobe}
+          />
+        ) : null}
       </View>
 
       <View style={styles.navBar}>
@@ -285,6 +299,7 @@ function AppContent({
           { key: 'wardrobe', label: 'Wardrobe' },
           { key: 'events', label: 'Calendar' },
           { key: 'plan', label: 'Outfits' },
+          { key: 'shop', label: 'Shop' },
           { key: 'profile', label: 'Profile' },
         ] as const).map((item) => {
           const active = tab === item.key;

--- a/misfitai-mobile/src/AppStateContext.tsx
+++ b/misfitai-mobile/src/AppStateContext.tsx
@@ -77,6 +77,7 @@ interface AppState {
   toggleGarmentHidden: (garmentId: string, hidden: boolean) => Promise<void>;
   deleteGarmentFromWardrobe: (garmentId: string) => Promise<void>;
   updateMeasurements: (data: Omit<BodyMeasurements, 'userId' | 'updatedAt'>) => Promise<void>;
+  refreshWardrobe: () => Promise<void>;
 }
 
 const AppStateContext = createContext<AppState | undefined>(undefined);
@@ -396,6 +397,11 @@ export function AppStateProvider({
     [userId]
   );
 
+  const refreshWardrobe = useCallback(async () => {
+    const wardrobe = await getWardrobe(userId);
+    setGarments(wardrobe);
+  }, [userId]);
+
   const value: AppState = useMemo(
     () => ({
       userId,
@@ -421,6 +427,7 @@ export function AppStateProvider({
       toggleGarmentHidden,
       deleteGarmentFromWardrobe,
       updateMeasurements,
+      refreshWardrobe,
     }),
     [
       userId,
@@ -446,6 +453,7 @@ export function AppStateProvider({
       toggleGarmentHidden,
       deleteGarmentFromWardrobe,
       updateMeasurements,
+      refreshWardrobe,
     ]
   );
 

--- a/misfitai-mobile/src/ProfileScreen.tsx
+++ b/misfitai-mobile/src/ProfileScreen.tsx
@@ -383,6 +383,7 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
   const [colorTone, setColorTone] = useState<ColorTone | null>(null);
   const [favoriteColors, setFavoriteColors] = useState<string[]>([]);
   const [avoidedColors, setAvoidedColors] = useState<string[]>([]);
+  const [favoriteBrandsText, setFavoriteBrandsText] = useState('');
   const [styleDirty, setStyleDirty] = useState(false);
   const [styleSaving, setStyleSaving] = useState(false);
 
@@ -413,6 +414,7 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
           setColorTone(p.colorTone ?? null);
           setFavoriteColors(p.favoriteColors ?? []);
           setAvoidedColors(p.avoidedColors ?? []);
+          setFavoriteBrandsText((p.favoriteBrands ?? []).join(', '));
           setTopSize(p.topSize ?? null);
           setBottomSize(p.bottomSize ?? null);
           setShoeSize(p.shoeSize ?? '');
@@ -482,11 +484,17 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
   const saveStyle = useCallback(async () => {
     setStyleSaving(true);
     try {
+      const favoriteBrands = favoriteBrandsText
+        .split(/[,]+/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .slice(0, 12);
       const updated = await updateUserProfile(userId, {
         skinTone,
         colorTone,
         favoriteColors,
         avoidedColors,
+        favoriteBrands,
       });
       setProfile(updated);
       setStyleDirty(false);
@@ -495,7 +503,7 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
     } finally {
       setStyleSaving(false);
     }
-  }, [userId, skinTone, colorTone, favoriteColors, avoidedColors]);
+  }, [userId, skinTone, colorTone, favoriteColors, avoidedColors, favoriteBrandsText]);
 
   const saveSizes = useCallback(async () => {
     setSizesSaving(true);
@@ -623,6 +631,7 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
     setColorTone(profile?.colorTone ?? null);
     setFavoriteColors(profile?.favoriteColors ?? []);
     setAvoidedColors(profile?.avoidedColors ?? []);
+    setFavoriteBrandsText((profile?.favoriteBrands ?? []).join(', '));
     setStyleDirty(false);
   };
   const discardSizes = () => {
@@ -759,6 +768,19 @@ export function ProfileScreen({ userId, displayName }: { userId: string; display
               setAvoidedColors(next);
               setStyleDirty(true);
             }}
+          />
+
+          <Text style={[s.label, { marginTop: 16 }]}>Favourite brands (optional)</Text>
+          <Text style={s.hint}>Comma-separated — used to personalise shop search.</Text>
+          <TextInput
+            value={favoriteBrandsText}
+            onChangeText={(v) => {
+              setFavoriteBrandsText(v);
+              setStyleDirty(true);
+            }}
+            placeholder="e.g. COS, Everlane, Nike"
+            placeholderTextColor={palette.muted}
+            style={s.input}
           />
         </View>
         <SaveBar dirty={styleDirty} saving={styleSaving} onSave={saveStyle} onDiscard={discardStyle} />

--- a/misfitai-mobile/src/ShopToCompleteScreen.tsx
+++ b/misfitai-mobile/src/ShopToCompleteScreen.tsx
@@ -1,0 +1,339 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import {
+  API_BASE_URL,
+  getApiErrorMessage,
+  getShopSuggestions,
+  markShopPurchased,
+  postShopEvent,
+} from './api';
+import { trackShopClick, trackShopImpression, trackShopPurchase } from './analytics';
+import { palette, radius, type } from './theme';
+import type { ShopProductOption, WardrobeGapSuggestion } from './types';
+
+function ProductThumbnail({
+  uri,
+  title,
+  productId,
+}: {
+  uri: string;
+  title: string;
+  productId: string;
+}) {
+  const fallback = React.useMemo(
+    () =>
+      `https://placehold.co/320x320/eaeaea/1a1a1a/png?text=${encodeURIComponent((title || 'Product').slice(0, 28))}`,
+    [title]
+  );
+  const [src, setSrc] = React.useState(uri);
+  React.useEffect(() => {
+    setSrc(uri);
+  }, [uri, productId]);
+
+  return (
+    <Image
+      source={{ uri: src }}
+      style={styles.productImg}
+      onError={() => setSrc((current) => (current === fallback ? current : fallback))}
+    />
+  );
+}
+
+export function ShopToCompleteScreen({
+  userId,
+  onWardrobeUpdated,
+}: {
+  userId: string;
+  onWardrobeUpdated: () => Promise<void>;
+}) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [gaps, setGaps] = useState<WardrobeGapSuggestion[]>([]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getShopSuggestions(userId);
+      setGaps(res.gaps);
+    } catch (err) {
+      const hint = __DEV__
+        ? `${getApiErrorMessage(err, '')}\nAPI: ${API_BASE_URL}`
+        : getApiErrorMessage(err, 'Could not load shop suggestions.');
+      setError(
+        hint.trim() ||
+          'Could not load shop suggestions. Check EXPO_PUBLIC_API_BASE_URL (use your computer IP on a physical phone) and that the backend is running.'
+      );
+      setGaps([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!gaps.length) return;
+    gaps.forEach((g) => {
+      postShopEvent(userId, { gapId: g.gapId, eventType: 'impression' }).catch(() => {});
+      trackShopImpression(g.gapId);
+    });
+  }, [gaps, userId]);
+
+  const openProduct = useCallback(
+    (gapId: string, p: ShopProductOption) => {
+      const url = (p.affiliateUrl || p.merchantUrl || '').trim();
+      if (!url) return;
+      postShopEvent(userId, { gapId, eventType: 'click', productId: p.id }).catch(() => {});
+      trackShopClick(gapId, p.id);
+      Linking.openURL(url).catch(() => {
+        Alert.alert('Could not open link');
+      });
+    },
+    [userId]
+  );
+
+  const onMarkPurchased = useCallback(
+    (gap: WardrobeGapSuggestion, p: ShopProductOption) => {
+      Alert.alert(
+        'Add to wardrobe?',
+        `Add “${p.title}” as ${gap.suggestedName}?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Add',
+            onPress: () => {
+              (async () => {
+                try {
+                  await markShopPurchased(userId, {
+                    gapId: gap.gapId,
+                    suggestedName: gap.suggestedName,
+                    title: p.title,
+                    primaryImageUrl: p.imageUrl,
+                    category: gap.targetCategory,
+                    formality: gap.targetFormality ?? undefined,
+                    color: null,
+                    brand: p.brand ?? null,
+                    productId: p.id,
+                    merchantUrl: p.merchantUrl,
+                  });
+                  trackShopPurchase(gap.gapId, p.id);
+                  await onWardrobeUpdated();
+                  await load();
+                  Alert.alert('Added', 'Item saved to your wardrobe.');
+                } catch {
+                  Alert.alert('Save failed', 'Could not add this item. Try again.');
+                }
+              })();
+            },
+          },
+        ]
+      );
+    },
+    [userId, load, onWardrobeUpdated]
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color={palette.accent} />
+        <Text style={styles.muted}>Finding gaps in your wardrobe…</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>{error}</Text>
+        <Pressable style={styles.retry} onPress={load}>
+          <Text style={styles.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (!gaps.length) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.title}>Your wardrobe looks complete</Text>
+        <Text style={styles.muted}>Check back after you add more clothes or change your week plan.</Text>
+        <Pressable style={styles.retry} onPress={load}>
+          <Text style={styles.retryText}>Refresh</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+      <Text style={styles.headline}>Shop to complete your wardrobe</Text>
+      <Text style={styles.disclosure}>
+        Purchase links go to retailers. We may earn a commission on qualifying purchases.
+      </Text>
+
+      {gaps.map((gap) => (
+        <View key={gap.gapId} style={styles.card}>
+          <Text style={styles.gapTitle}>{gap.title}</Text>
+          <Text style={styles.gapReason}>{gap.reason}</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.carousel}>
+            {gap.products.map((p) => (
+              <View key={p.id} style={styles.product}>
+                <ProductThumbnail uri={p.imageUrl} title={p.title} productId={p.id} />
+                <Text style={styles.productTitle} numberOfLines={2}>
+                  {p.title}
+                </Text>
+                {p.brand ? <Text style={styles.brand}>{p.brand}</Text> : null}
+                {p.priceDisplay ? <Text style={styles.price}>{p.priceDisplay}</Text> : null}
+                <Pressable
+                  style={styles.btnSecondary}
+                  onPress={() => openProduct(gap.gapId, p)}
+                >
+                  <Text style={styles.btnSecondaryText}>View</Text>
+                </Pressable>
+                <Pressable
+                  style={styles.btnPrimary}
+                  onPress={() => onMarkPurchased(gap, p)}
+                >
+                  <Text style={styles.btnPrimaryText}>Mark purchased</Text>
+                </Pressable>
+              </View>
+            ))}
+          </ScrollView>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: { flex: 1 },
+  scrollContent: { padding: 20, paddingBottom: 48 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
+  headline: {
+    fontFamily: type.title,
+    fontSize: 22,
+    marginBottom: 8,
+    color: palette.ink,
+  },
+  disclosure: {
+    fontFamily: type.body,
+    fontSize: 13,
+    color: palette.muted,
+    marginBottom: 20,
+    lineHeight: 18,
+  },
+  title: {
+    fontFamily: type.bodyDemi,
+    fontSize: 18,
+    color: palette.ink,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  muted: {
+    fontFamily: type.body,
+    fontSize: 15,
+    color: palette.muted,
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  error: {
+    fontFamily: type.body,
+    fontSize: 15,
+    color: palette.error,
+    textAlign: 'center',
+  },
+  retry: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    backgroundColor: palette.panel,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: palette.line,
+  },
+  retryText: { fontFamily: type.bodyMedium, fontSize: 14, color: palette.ink },
+  card: {
+    backgroundColor: palette.panel,
+    borderRadius: radius.lg,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: palette.line,
+  },
+  gapTitle: {
+    fontFamily: type.bodyDemi,
+    fontSize: 17,
+    color: palette.ink,
+    marginBottom: 6,
+  },
+  gapReason: {
+    fontFamily: type.body,
+    fontSize: 14,
+    color: palette.muted,
+    marginBottom: 12,
+    lineHeight: 20,
+  },
+  carousel: { flexGrow: 0 },
+  product: {
+    width: 160,
+    marginRight: 12,
+    padding: 10,
+    backgroundColor: palette.bgAlt,
+    borderRadius: radius.md,
+  },
+  productImg: {
+    width: '100%',
+    height: 120,
+    borderRadius: radius.sm,
+    backgroundColor: palette.line,
+  },
+  productTitle: {
+    fontFamily: type.bodyMedium,
+    fontSize: 13,
+    marginTop: 8,
+    minHeight: 36,
+    color: palette.ink,
+  },
+  brand: { fontFamily: type.body, fontSize: 12, color: palette.muted },
+  price: {
+    fontFamily: type.bodyDemi,
+    fontSize: 13,
+    marginTop: 4,
+    color: palette.ink,
+  },
+  btnSecondary: {
+    marginTop: 8,
+    paddingVertical: 8,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    borderColor: palette.line,
+    alignItems: 'center',
+  },
+  btnSecondaryText: { fontFamily: type.body, fontSize: 13, color: palette.ink },
+  btnPrimary: {
+    marginTop: 6,
+    paddingVertical: 8,
+    borderRadius: radius.sm,
+    backgroundColor: palette.ink,
+    alignItems: 'center',
+  },
+  btnPrimaryText: {
+    fontFamily: type.bodyMedium,
+    fontSize: 13,
+    color: palette.textOnAccent,
+    fontWeight: '600',
+  },
+});

--- a/misfitai-mobile/src/__tests__/api.test.ts
+++ b/misfitai-mobile/src/__tests__/api.test.ts
@@ -177,6 +177,8 @@ describe('updateUserProfile (mock mode)', () => {
     expect(result).toHaveProperty('userId');
     expect(result).toHaveProperty('favoriteColors');
     expect(Array.isArray(result.favoriteColors)).toBe(true);
+    expect(result).toHaveProperty('favoriteBrands');
+    expect(Array.isArray(result.favoriteBrands)).toBe(true);
   });
 });
 

--- a/misfitai-mobile/src/analytics.ts
+++ b/misfitai-mobile/src/analytics.ts
@@ -6,3 +6,9 @@ export function initAnalytics(): void {}
 export function trackAuthSuccess(provider: string): void {
   void provider;
 }
+
+export function trackShopImpression(_gapId: string): void {}
+
+export function trackShopClick(_gapId: string, _productId: string): void {}
+
+export function trackShopPurchase(_gapId: string, _productId: string): void {}

--- a/misfitai-mobile/src/analytics.web.ts
+++ b/misfitai-mobile/src/analytics.web.ts
@@ -29,3 +29,41 @@ export function trackAuthSuccess(provider: string): void {
     label: provider,
   });
 }
+
+export function trackShopImpression(gapId: string): void {
+  if (!measurementId) {
+    return;
+  }
+  if (!initialized) {
+    initAnalytics();
+  }
+  ReactGA.event({ category: 'shop', action: 'shop_impression', label: gapId });
+}
+
+export function trackShopClick(gapId: string, productId: string): void {
+  if (!measurementId) {
+    return;
+  }
+  if (!initialized) {
+    initAnalytics();
+  }
+  ReactGA.event({
+    category: 'shop',
+    action: 'shop_click',
+    label: `${gapId}:${productId}`,
+  });
+}
+
+export function trackShopPurchase(gapId: string, productId: string): void {
+  if (!measurementId) {
+    return;
+  }
+  if (!initialized) {
+    initAnalytics();
+  }
+  ReactGA.event({
+    category: 'shop',
+    action: 'shop_purchase',
+    label: `${gapId}:${productId}`,
+  });
+}

--- a/misfitai-mobile/src/api.ts
+++ b/misfitai-mobile/src/api.ts
@@ -12,16 +12,41 @@ import type {
   GarmentFormality,
   GarmentGender,
   GarmentSeasonality,
+  ShopProductOption,
+  ShopSuggestionsResponse,
   UserProfile,
   UserProfileUpdate,
+  WardrobeGapSuggestion,
 } from './types';
 
 const DEFAULT_API_BASE_URL =
   Platform.OS === 'android' ? 'http://10.0.2.2:8000' : 'http://127.0.0.1:8000';
 
-export const API_BASE_URL = (
-  process.env.EXPO_PUBLIC_API_BASE_URL ?? DEFAULT_API_BASE_URL
-).replace(/\/$/, '');
+/**
+ * Android emulator: ``127.0.0.1`` / ``localhost`` in ``.env`` points at the emulator, not the host.
+ * Rewrite to ``10.0.2.2`` so the same .env works on iOS simulator + web + Android emulator.
+ * Physical devices still need your machine's LAN IP in ``EXPO_PUBLIC_API_BASE_URL``.
+ */
+function normalizeApiBaseUrl(raw: string): string {
+  const trimmed = raw.trim().replace(/\/$/, '');
+  const base = trimmed || DEFAULT_API_BASE_URL;
+  if (Platform.OS !== 'android') {
+    return base;
+  }
+  try {
+    const parsed = new URL(base.includes('://') ? base : `http://${base}`);
+    if (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost') {
+      parsed.hostname = '10.0.2.2';
+      return parsed.toString().replace(/\/$/, '');
+    }
+  } catch {
+    /* keep base */
+  }
+  return base;
+}
+
+const fromEnvUrl = (process.env.EXPO_PUBLIC_API_BASE_URL ?? '').trim();
+export const API_BASE_URL = normalizeApiBaseUrl(fromEnvUrl || DEFAULT_API_BASE_URL);
 
 export const USE_MOCK_API =
   process.env.EXPO_PUBLIC_USE_MOCK_API === 'true'
@@ -213,11 +238,12 @@ interface RecommendationApi {
 
 export interface AddGarmentPayload {
   name: string;
-  category: 'top' | 'bottom' | 'shoes' | 'accessory';
+  category: GarmentCategory;
   color?: string;
   formality?: GarmentFormality;
   seasonality?: GarmentSeasonality;
   primaryImageUrl?: string;
+  brand?: string;
 }
 
 export interface VisionAddPayload {
@@ -253,7 +279,7 @@ export interface GarmentSearchOptions {
 }
 export interface ConfirmSearchAddPayload {
   name: string;
-  category: 'top' | 'bottom' | 'shoes' | 'accessory';
+  category: GarmentCategory;
   color?: string;
   formality?: GarmentFormality;
   seasonality?: GarmentSeasonality;
@@ -773,6 +799,7 @@ export async function addGarment(
         seasonality: payload.seasonality ?? 'all_season',
         primary_image_url:
           payload.primaryImageUrl ?? 'https://example.com/garment-placeholder.jpg',
+        brand: payload.brand ?? undefined,
       }),
     }
   );
@@ -1069,6 +1096,7 @@ interface ProfileApiResponse {
   color_tone?: string | null;
   favorite_colors?: string[];
   avoided_colors?: string[];
+  favorite_brands?: string[];
   shoe_size?: string | null;
   top_size?: string | null;
   bottom_size?: string | null;
@@ -1091,6 +1119,7 @@ function mapUserProfile(r: ProfileApiResponse): UserProfile {
     colorTone: (r.color_tone as UserProfile['colorTone']) ?? null,
     favoriteColors: r.favorite_colors ?? [],
     avoidedColors: r.avoided_colors ?? [],
+    favoriteBrands: r.favorite_brands ?? [],
     shoeSize: r.shoe_size ?? null,
     topSize: r.top_size ?? null,
     bottomSize: r.bottom_size ?? null,
@@ -1128,6 +1157,7 @@ export function profileUpdateToApiPayload(data: UserProfileUpdate): Record<strin
   if (data.colorTone !== undefined) payload.color_tone = data.colorTone;
   if (data.favoriteColors !== undefined) payload.favorite_colors = data.favoriteColors;
   if (data.avoidedColors !== undefined) payload.avoided_colors = data.avoidedColors;
+  if (data.favoriteBrands !== undefined) payload.favorite_brands = data.favoriteBrands;
   if (data.shoeSize !== undefined) payload.shoe_size = data.shoeSize;
   if (data.topSize !== undefined) payload.top_size = data.topSize;
   if (data.bottomSize !== undefined) payload.bottom_size = data.bottomSize;
@@ -1161,6 +1191,7 @@ export async function updateUserProfile(
       userId,
       favoriteColors: data.favoriteColors ?? [],
       avoidedColors: data.avoidedColors ?? [],
+      favoriteBrands: data.favoriteBrands ?? [],
       ...data,
     };
   }
@@ -1172,6 +1203,154 @@ export async function updateUserProfile(
     }
   );
   return mapUserProfile(response);
+}
+
+// ---------------------------------------------------------------------------
+// Shop — wardrobe gaps
+// ---------------------------------------------------------------------------
+
+interface ShopProductApi {
+  id: string;
+  title: string;
+  brand?: string | null;
+  price_display?: string | null;
+  image_url: string;
+  merchant_url: string;
+  affiliate_url?: string | null;
+}
+
+interface WardrobeGapApi {
+  gap_id: string;
+  title: string;
+  reason: string;
+  target_category: string;
+  target_formality?: string | null;
+  suggested_name: string;
+  products?: ShopProductApi[];
+}
+
+function mapShopProduct(p: ShopProductApi): ShopProductOption {
+  return {
+    id: p.id,
+    title: p.title,
+    brand: p.brand,
+    priceDisplay: p.price_display,
+    imageUrl: p.image_url,
+    merchantUrl: p.merchant_url,
+    affiliateUrl: p.affiliate_url,
+  };
+}
+
+function mapWardrobeGap(g: WardrobeGapApi): WardrobeGapSuggestion {
+  return {
+    gapId: g.gap_id,
+    title: g.title,
+    reason: g.reason,
+    targetCategory: normalizeCategory(g.target_category),
+    targetFormality: g.target_formality
+      ? (normalizeFormality(g.target_formality) as GarmentFormality)
+      : null,
+    suggestedName: g.suggested_name,
+    products: Array.isArray(g.products) ? g.products.map(mapShopProduct) : [],
+  };
+}
+
+export async function getShopSuggestions(userId: string): Promise<ShopSuggestionsResponse> {
+  if (USE_MOCK_API) {
+    return {
+      userId,
+      gaps: [
+        {
+          gapId: 'neutral_shoes',
+          title: 'Neutral everyday shoes (mock)',
+          reason:
+            'Mock API mode is on. Set EXPO_PUBLIC_USE_MOCK_API=false in misfitai-mobile/.env and restart Expo with -c to use your backend.',
+          targetCategory: 'shoes',
+          targetFormality: 'smart_casual',
+          suggestedName: 'White sneakers',
+          products: [
+            {
+              id: 'mock-1',
+              title: 'Example sneaker',
+              brand: 'Demo',
+              priceDisplay: '$0',
+              imageUrl: 'https://via.placeholder.com/320x320.png?text=Mock+product',
+              merchantUrl: 'https://example.com',
+            },
+          ],
+        },
+      ],
+    };
+  }
+  const r = await requestJson<{ user_id?: string; gaps?: WardrobeGapApi[] }>(
+    `/users/${encodeURIComponent(userId)}/shop/suggestions`
+  );
+  const gaps = Array.isArray(r.gaps) ? r.gaps.map(mapWardrobeGap) : [];
+  return { userId: r.user_id ?? userId, gaps };
+}
+
+export async function postShopEvent(
+  userId: string,
+  payload: { gapId: string; eventType: string; productId?: string | null }
+): Promise<void> {
+  if (USE_MOCK_API) return;
+  await requestJson(`/users/${encodeURIComponent(userId)}/shop/events`, {
+    method: 'POST',
+    body: JSON.stringify({
+      gap_id: payload.gapId,
+      event_type: payload.eventType,
+      product_id: payload.productId ?? undefined,
+    }),
+  });
+}
+
+export async function markShopPurchased(
+  userId: string,
+  payload: {
+    gapId: string;
+    suggestedName: string;
+    title: string;
+    primaryImageUrl: string;
+    category: GarmentCategory;
+    formality?: GarmentFormality | null;
+    seasonality?: GarmentSeasonality | null;
+    color?: string | null;
+    brand?: string | null;
+    productId?: string | null;
+    merchantUrl?: string | null;
+  }
+): Promise<Garment> {
+  if (USE_MOCK_API) {
+    return mockAddGarment(userId, {
+      name: payload.suggestedName,
+      category: payload.category,
+      color: payload.color ?? undefined,
+      formality: payload.formality ?? undefined,
+      seasonality: payload.seasonality ?? undefined,
+      primaryImageUrl: payload.primaryImageUrl,
+      brand: payload.brand ?? undefined,
+    });
+  }
+  const raw = await requestJson<WardrobeApiItem>(
+    `/users/${encodeURIComponent(userId)}/shop/mark-purchased`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        gap_id: payload.gapId,
+        suggested_name: payload.suggestedName,
+        title: payload.title,
+        primary_image_url: payload.primaryImageUrl,
+        category: payload.category,
+        formality: payload.formality ?? undefined,
+        seasonality: payload.seasonality ?? undefined,
+        color: payload.color ?? undefined,
+        brand: payload.brand ?? undefined,
+        product_id: payload.productId ?? undefined,
+        merchant_url: payload.merchantUrl ?? undefined,
+      }),
+    }
+  );
+  return mapGarment(raw);
 }
 
 // ---------------------------------------------------------------------------

--- a/misfitai-mobile/src/types.ts
+++ b/misfitai-mobile/src/types.ts
@@ -113,6 +113,7 @@ export interface UserProfile {
   colorTone?: ColorTone | null;
   favoriteColors: string[];
   avoidedColors: string[];
+  favoriteBrands: string[];
   shoeSize?: string | null;
   topSize?: string | null;
   bottomSize?: string | null;
@@ -128,8 +129,38 @@ export interface UserProfileUpdate {
   colorTone?: ColorTone | null;
   favoriteColors?: string[];
   avoidedColors?: string[];
+  favoriteBrands?: string[];
   shoeSize?: string | null;
   topSize?: string | null;
   bottomSize?: string | null;
   avatarConfig?: AvatarConfig | null;
+}
+
+// ---------------------------------------------------------------------------
+// Shop — wardrobe gaps
+// ---------------------------------------------------------------------------
+
+export interface ShopProductOption {
+  id: string;
+  title: string;
+  brand?: string | null;
+  priceDisplay?: string | null;
+  imageUrl: string;
+  merchantUrl: string;
+  affiliateUrl?: string | null;
+}
+
+export interface WardrobeGapSuggestion {
+  gapId: string;
+  title: string;
+  reason: string;
+  targetCategory: GarmentCategory;
+  targetFormality?: GarmentFormality | null;
+  suggestedName: string;
+  products: ShopProductOption[];
+}
+
+export interface ShopSuggestionsResponse {
+  userId: string;
+  gaps: WardrobeGapSuggestion[];
 }

--- a/scripts/sql/shop_engagement_events.sql
+++ b/scripts/sql/shop_engagement_events.sql
@@ -1,0 +1,24 @@
+-- Append-only shop funnel events (impression, click, dismiss, add_to_wardrobe).
+-- Run in Supabase SQL editor. Enable RLS and add policies so each user_id
+-- can only insert/select own rows if clients use the anon key; with service
+-- role (backend only), RLS can remain disabled.
+
+create table if not exists public.shop_engagement_events (
+  id          bigserial primary key,
+  user_id     text not null,
+  gap_id      text not null,
+  event_type  text not null,
+  product_id  text,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists shop_engagement_events_user_id_created_at_idx
+  on public.shop_engagement_events (user_id, created_at desc);
+
+comment on table public.shop_engagement_events is
+  'Shop feature analytics: views, outbound clicks, dismissals, add-to-wardrobe.';
+
+-- Example RLS (optional; adjust to your auth model):
+-- alter table public.shop_engagement_events enable row level security;
+-- create policy "Users insert own shop events"
+--   on public.shop_engagement_events for insert with check (auth.uid()::text = user_id);

--- a/scripts/sql/user_profiles_favorite_brands.sql
+++ b/scripts/sql/user_profiles_favorite_brands.sql
@@ -1,0 +1,8 @@
+-- Add favorite retail brands for shop query personalization.
+-- Run in Supabase SQL editor after user_profiles exists.
+
+alter table public.user_profiles
+  add column if not exists favorite_brands text[] default '{}';
+
+comment on column public.user_profiles.favorite_brands is
+  'Brands the user wants prioritised in Shop search queries.';


### PR DESCRIPTION
## Summary

Adds an end-to-end **“Shop to complete your wardrobe”** experience: detect wardrobe gaps from inventory + calendar context, fetch product options (SerpAPI Google Shopping with curated JSON fallback + TTL cache), expose REST endpoints for suggestions/events/mark-purchased, and ship a **Shop** tab in the mobile app with analytics. Includes **profile `favorite_brands`**, improved **product image reliability** (richer SerpAPI field parsing, HTTPS placeholders, client-side `Image` fallback), and **dev/reliability** tweaks (API base URL normalization for Android emulator, CORS/origin notes, clearer shop load errors in `__DEV__`).

## Backend

- **`wardrobe_gaps`**: inventory summary, optional calendar weighting, rule-based `detect_gaps`, `build_shop_query`, optional LLM gap ranking (`SHOP_GAP_LLM_RANK`).
- **`shop_products`**: `SerpApiShoppingProvider`, `CuratedProductProvider`, `normalize_shopping_result`, in-memory TTL cache (`SHOP_CACHE_TTL_SEC`), affiliate query suffix support, deduping + preference for rows with real thumbnails; protocol-relative image URLs and extra image fields (`img`, `images`, nested thumbnails, etc.).
- **`shop_router`**: `GET /shop/suggestions`, `POST /shop/events`, `POST /shop/mark-purchased` (adds garment to wardrobe); engagement logging to DB.
- **`models` / `profile_router`**: shop DTOs; **`favorite_brands`** on user profile.
- **`db`**: helpers for shop engagement events + profile brand persistence (see `scripts/sql/`).
- **`main`**: CORS / allowed origins adjustments for Expo web; garment **`brand`** on add-garment where applicable.
- **Tests**: unit tests for gaps + shop normalization/provider; integration tests for shop routes (local wardrobe store in tests to avoid live Supabase).

## Mobile (`misfitai-mobile`)

- **Shop tab** + **`ShopToCompleteScreen`**: horizontal product carousels per gap, open retailer links, mark purchased (refresh wardrobe).
- **`api.ts`**: shop clients; **`normalizeApiBaseUrl`** so Android emulator uses `10.0.2.2` instead of `localhost` where appropriate.
- **`ProfileScreen`**: edit **favorite brands**.
- **`analytics` / `analytics.web`**: shop impression / click / purchase events.
- **Types** + **`AppStateContext`** wiring as needed for refresh after purchase.

## Data / config

- **`data/shop_curated_products.json`**: curated fallback products keyed by gap id.
- **`.env.example`** (root + mobile): documents `SERPAPI_KEY`, `SHOP_*` knobs, API base URL notes for physical devices.

## How to test

1. Set `SERPAPI_KEY` (and optional `SHOP_PRODUCT_PROVIDER`, `SHOP_CACHE_TTL_SEC`, `SHOP_AFFILIATE_QUERY_SUFFIX`) per `.env.example`.
2. Run backend + Expo; open **Shop** tab with a user that has gaps (or mock path in dev).
3. Confirm each product tile shows an image (real thumbnail or placeholder after load error).
4. **View** opens external link; **Mark purchased** adds item and wardrobe refresh runs.
5. `pytest` for `test_wardrobe_gaps`, `test_shop_products`, `test_shop_routes`, and existing recommendation tests.

## Notes / follow-ups

- Shop responses may be cached in-memory until TTL; restart API or lower `SHOP_CACHE_TTL_SEC` when validating SerpAPI/image changes.
- Purchase links / affiliate behavior depend on env and retailer responses; disclosure copy is shown in-app.