### PR TITLE
Preserve & Pin Original Outfit Feature

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -35,6 +35,7 @@ _local_measurements: dict[str, BodyMeasurements] = {}
 _local_user_profiles: dict[str, UserProfile] = {}
 # OAuth logins (no Supabase Auth): POST /analytics/register fills this in local dev.
 _local_signup_user_ids: set[str] = set()
+_local_recommendation_choice_events: list[dict[str, Any]] = []
 # Email/password users when Supabase is unavailable or table writes fall back (see create_password_user).
 _local_app_users_by_email: dict[str, dict[str, str]] = {}
 
@@ -84,6 +85,10 @@ def _signup_registry_table() -> str:
 
 def _app_users_table() -> str:
     return (os.getenv("SUPABASE_APP_USERS_TABLE") or "app_users").strip() or "app_users"
+
+
+def _recommendation_choices_table() -> str:
+    return (os.getenv("SUPABASE_RECOMMENDATION_CHOICES_TABLE") or "recommendation_choice_events").strip() or "recommendation_choice_events"
 
 
 def normalize_login_email(email: str) -> str:
@@ -227,6 +232,37 @@ def count_registered_signups() -> int:
     except Exception:
         logger.exception("count_registered_signups failed")
         return 0
+
+
+def track_recommendation_choice(
+    *,
+    user_id: str,
+    day: str,
+    chosen_variant_id: str,
+    source_type: str,
+    pin_whole_outfit: bool = False,
+    pinned_piece_keys: Optional[list[str]] = None,
+) -> None:
+    """Record recommendation variant chosen by user (best-effort)."""
+    uid = (user_id or "").strip()
+    if not uid:
+        return
+    payload = {
+        "user_id": uid,
+        "day": (day or "").strip(),
+        "chosen_variant_id": (chosen_variant_id or "").strip(),
+        "source_type": (source_type or "").strip() or "unknown",
+        "pin_whole_outfit": bool(pin_whole_outfit),
+        "pinned_piece_keys": list(pinned_piece_keys or []),
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    if _use_local_store():
+        _local_recommendation_choice_events.append(payload)
+        return
+    try:
+        get_supabase_client().table(_recommendation_choices_table()).insert(payload).execute()
+    except Exception:
+        logger.exception("track_recommendation_choice failed user_id=%r", uid[:80])
 
 
 def _parse_category(value: Any) -> GarmentCategory:

--- a/backend/models.py
+++ b/backend/models.py
@@ -260,6 +260,16 @@ class WeekEvent(BaseModel):
     fetch a point-in-time weather forecast."""
 
 
+class PinnedRecommendationConstraint(BaseModel):
+    """Pin constraints for one day while regenerating recommendations."""
+
+    day: str
+    pin_whole_outfit: bool = False
+    top_id: Optional[str] = None
+    bottom_id: Optional[str] = None
+    dress_id: Optional[str] = None
+
+
 class WeekRecommendationRequest(BaseModel):
     """Request body for ``POST /recommendations/week``."""
 
@@ -270,6 +280,9 @@ class WeekRecommendationRequest(BaseModel):
     user_gender: Optional[str] = None
     """Gender identity of the user (``"male"``, ``"female"``, or ``"other"``).
     When provided, garments tagged for the opposite binary gender are excluded."""
+
+    pin_constraints: List[PinnedRecommendationConstraint] = []
+    """Optional per-day pin rules used during regeneration."""
 
 
 class DayOutfitSuggestion(BaseModel):

--- a/backend/recommendation.py
+++ b/backend/recommendation.py
@@ -14,7 +14,14 @@ from __future__ import annotations
 from typing import Optional
 
 from .llm import generate_outfit_explanation
-from .models import BodyMeasurements, DayOutfitSuggestion, GarmentItem, UserProfile, WeekEvent
+from .models import (
+    BodyMeasurements,
+    DayOutfitSuggestion,
+    GarmentItem,
+    PinnedRecommendationConstraint,
+    UserProfile,
+    WeekEvent,
+)
 
 # ---------------------------------------------------------------------------
 # Category sets — checked against both category.value and sub_category
@@ -437,6 +444,7 @@ async def generate_week_recommendations(
     user_gender: Optional[str] = None,
     measurements: Optional[BodyMeasurements] = None,
     user_profile: Optional[UserProfile] = None,
+    pin_constraints: Optional[list[PinnedRecommendationConstraint]] = None,
 ) -> list[DayOutfitSuggestion]:
     """
     Generate one :class:`DayOutfitSuggestion` per event in *events*.
@@ -483,29 +491,52 @@ async def generate_week_recommendations(
         user_size_label = _derive_size_label(measurements)
 
     used_ids: set[str] = set()
+    wardrobe_by_id = {g.id: g for g in wardrobe if getattr(g, "id", None)}
+    pin_by_day = {
+        c.day.strip().lower(): c
+        for c in (pin_constraints or [])
+        if getattr(c, "day", None)
+    }
     recommendations: list[DayOutfitSuggestion] = []
 
     for event in events:
+        day_key = (event.day or "").strip().lower()
+        pin = pin_by_day.get(day_key)
         formality_chain = _FORMALITY_FALLBACK_CHAINS.get(
             event.event_type, _FALLBACK_FORMALITY_CHAIN
         )
 
-        top = _pick_garment(
-            wardrobe, _is_top, formality_chain, used_ids,
-            event_type=event.event_type,
-            user_size_label=user_size_label,
-            user_profile=user_profile,
-        )
-        bottom = _pick_garment(
-            wardrobe, _is_bottom, formality_chain, used_ids,
-            event_type=event.event_type,
-            user_size_label=user_size_label,
-            user_profile=user_profile,
-        )
+        pinned_top = wardrobe_by_id.get(pin.top_id) if pin and pin.top_id else None
+        pinned_bottom = wardrobe_by_id.get(pin.bottom_id) if pin and pin.bottom_id else None
+        pinned_dress = wardrobe_by_id.get(pin.dress_id) if pin and pin.dress_id else None
+
+        if pin and pin.pin_whole_outfit:
+            # Whole-outfit pin takes priority: keep selected pieces fixed.
+            if pinned_dress is not None:
+                top = None
+                bottom = None
+                dress = pinned_dress
+            else:
+                top = pinned_top
+                bottom = pinned_bottom
+                dress = None
+        else:
+            top = pinned_top or _pick_garment(
+                wardrobe, _is_top, formality_chain, used_ids,
+                event_type=event.event_type,
+                user_size_label=user_size_label,
+                user_profile=user_profile,
+            )
+            bottom = pinned_bottom or _pick_garment(
+                wardrobe, _is_bottom, formality_chain, used_ids,
+                event_type=event.event_type,
+                user_size_label=user_size_label,
+                user_profile=user_profile,
+            )
+            dress = pinned_dress
 
         # If top or bottom is missing, try a dress as a fallback
-        dress = None
-        if top is None or bottom is None:
+        if dress is None and (top is None or bottom is None):
             dress = _pick_garment(
                 wardrobe, _is_dress, formality_chain, used_ids,
                 event_type=event.event_type,

--- a/backend/routers/analytics_router.py
+++ b/backend/routers/analytics_router.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from starlette.responses import Response
 
 from ..analytics_metrics import build_analytics_summary
-from ..db import register_signup_user_id
+from ..db import register_signup_user_id, track_recommendation_choice
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
@@ -59,6 +59,15 @@ class RegisterSignupBody(BaseModel):
     user_id: str = Field(..., max_length=512, description="Same stable id the app uses for wardrobe API calls.")
 
 
+class RecommendationChoiceBody(BaseModel):
+    user_id: str = Field(..., max_length=512)
+    day: str = Field(..., max_length=32)
+    chosen_variant_id: str = Field(..., max_length=128)
+    source_type: str = Field(..., max_length=32)
+    pin_whole_outfit: bool = False
+    pinned_piece_keys: list[str] = []
+
+
 @router.post("/register", status_code=204)
 def register_signup(body: RegisterSignupBody) -> Response:
     """
@@ -68,6 +77,20 @@ def register_signup(body: RegisterSignupBody) -> Response:
     Not protected by ``X-Analytics-Key`` (the app must call this anonymously).
     """
     register_signup_user_id(body.user_id)
+    return Response(status_code=204)
+
+
+@router.post("/recommendation-choice", status_code=204)
+def register_recommendation_choice(body: RecommendationChoiceBody) -> Response:
+    """Record which recommendation option the user chose."""
+    track_recommendation_choice(
+        user_id=body.user_id,
+        day=body.day,
+        chosen_variant_id=body.chosen_variant_id,
+        source_type=body.source_type,
+        pin_whole_outfit=body.pin_whole_outfit,
+        pinned_piece_keys=body.pinned_piece_keys,
+    )
     return Response(status_code=204)
 
 

--- a/backend/routers/recommendations.py
+++ b/backend/routers/recommendations.py
@@ -89,6 +89,7 @@ async def recommend_week(
         user_gender=request.user_gender,
         measurements=measurements,
         user_profile=user_profile,
+        pin_constraints=request.pin_constraints,
     )
 
     # Increment usage counters for recommended garments (best-effort).

--- a/backend/tests/test_integration/test_analytics_routes.py
+++ b/backend/tests/test_integration/test_analytics_routes.py
@@ -26,6 +26,23 @@ class TestRegisterSignup:
 
 
 @pytest.mark.usefixtures("_isolate_env")
+class TestRecommendationChoice:
+    async def test_tracks_choice_returns_204(self, client):
+        resp = await client.post(
+            "/analytics/recommendation-choice",
+            json={
+                "user_id": "test-user-1",
+                "day": "monday",
+                "chosen_variant_id": "monday-original-1",
+                "source_type": "original",
+                "pin_whole_outfit": False,
+                "pinned_piece_keys": ["top"],
+            },
+        )
+        assert resp.status_code == 204
+
+
+@pytest.mark.usefixtures("_isolate_env")
 class TestGetMetrics:
     async def test_no_auth_required_by_default(self, client):
         resp = await client.get("/analytics/metrics")

--- a/backend/tests/test_integration/test_recommendation_routes.py
+++ b/backend/tests/test_integration/test_recommendation_routes.py
@@ -74,3 +74,47 @@ class TestRecommendWeek:
         stored = resp.json()["events"]
         assert len(stored) == 1
         assert stored[0]["day"] == "Wednesday"
+
+    async def test_respects_pin_constraints(self, client):
+        top = await client.post(
+            "/wardrobe/test-user/items",
+            json={
+                "name": "Pinned white shirt",
+                "category": "top",
+                "primary_image_url": "https://example.com/shirt.jpg",
+                "formality": "business",
+            },
+        )
+        bottom = await client.post(
+            "/wardrobe/test-user/items",
+            json={
+                "name": "Pinned dark trousers",
+                "category": "bottom",
+                "primary_image_url": "https://example.com/pants.jpg",
+                "formality": "business",
+            },
+        )
+        assert top.status_code == 200
+        assert bottom.status_code == 200
+        top_id = top.json()["id"]
+        bottom_id = bottom.json()["id"]
+
+        resp = await client.post(
+            "/recommendations/week",
+            json={
+                "user_id": "test-user",
+                "events": [{"day": "Monday", "event_type": "work_meeting"}],
+                "pin_constraints": [
+                    {
+                        "day": "Monday",
+                        "pin_whole_outfit": True,
+                        "top_id": top_id,
+                        "bottom_id": bottom_id,
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        rec = resp.json()["recommendations"][0]
+        assert rec["top_id"] == top_id
+        assert rec["bottom_id"] == bottom_id

--- a/misfitai-mobile/src/AppStateContext.tsx
+++ b/misfitai-mobile/src/AppStateContext.tsx
@@ -9,12 +9,15 @@ import React, {
 import type {
   BodyMeasurements,
   CalendarEvent,
+  DayRecommendationSet,
   DayOfWeek,
   DayRecommendation,
   EventType,
   Garment,
   GarmentSeasonality,
   GarmentFormality,
+  RecommendationPinnedPieces,
+  RecommendationVariant,
 } from './types';
 import { dayOrder } from './constants';
 import {
@@ -33,9 +36,12 @@ import {
   deleteGarment as apiDeleteGarment,
   setGarmentHidden as apiSetGarmentHidden,
   syncCalendarEvents as apiSyncCalendarEvents,
+  trackRecommendationChoice,
   type ConfirmSearchAddPayload,
   type GarmentSearchResult,
   type GarmentSearchOptions,
+  type RecommendationPinConstraint,
+  type RecommendationChoicePayload,
   type VisionAddPayload,
   type VisionPreviewItem,
   saveWeekEvents,
@@ -47,6 +53,7 @@ interface AppState {
   eventsByDay: Record<DayOfWeek, EventType>;
   summariesByDay: Record<DayOfWeek, string | undefined>;
   recommendations: DayRecommendation[];
+  recommendationSets: DayRecommendationSet[];
   isCalendarConnected: boolean;
   isLoadingWardrobe: boolean;
   wardrobeError: string | null;
@@ -61,6 +68,15 @@ interface AppState {
   useDemoWeek: () => void;
   syncCalendarEvents: () => Promise<void>;
   generateRecommendations: () => Promise<void>;
+  regenerateRecommendationsWithPins: () => Promise<void>;
+  setSelectedRecommendationVariant: (day: DayOfWeek, variantId: string) => Promise<void>;
+  setPinWholeOutfit: (day: DayOfWeek, variantId: string, pinned: boolean) => void;
+  setPinPiece: (
+    day: DayOfWeek,
+    variantId: string,
+    piece: keyof RecommendationPinnedPieces,
+    pinned: boolean
+  ) => void;
   addGarmentToWardrobe: (
     payload: {
       name: string;
@@ -113,6 +129,30 @@ function createInitialSummaries(): Record<DayOfWeek, string | undefined> {
   };
 }
 
+function emptyPinnedPieces(): RecommendationPinnedPieces {
+  return { top: false, bottom: false, dress: false };
+}
+
+function createVariantLabel(index: number): string {
+  return index === 0 ? 'First suggestion' : `Regenerated option ${index + 1}`;
+}
+
+function buildVariant(
+  recommendation: DayRecommendation,
+  index: number,
+  sourceType: 'original' | 'regenerated',
+  previous?: RecommendationVariant
+): RecommendationVariant {
+  return {
+    id: previous?.id ?? `${recommendation.day}-${sourceType}-${index}-${recommendation.outfit.id || 'outfit'}`,
+    label: createVariantLabel(index),
+    sourceType,
+    recommendation,
+    pinWholeOutfit: previous?.pinWholeOutfit ?? false,
+    pinnedPieces: previous?.pinnedPieces ?? emptyPinnedPieces(),
+  };
+}
+
 export function AppStateProvider({
   children,
   userId: userIdProp,
@@ -136,6 +176,7 @@ export function AppStateProvider({
   const [recommendations, setRecommendations] = useState<
     DayRecommendation[]
   >([]);
+  const [recommendationSets, setRecommendationSets] = useState<DayRecommendationSet[]>([]);
   const [isLoadingWardrobe, setIsLoadingWardrobe] = useState(false);
   const [wardrobeError, setWardrobeError] = useState<string | null>(null);
   const [measurements, setMeasurements] = useState<BodyMeasurements | null>(null);
@@ -287,20 +328,194 @@ export function AppStateProvider({
     }
   }, [userId, googleAccessToken]);
 
-  const generateRecommendations = useCallback(async () => {
-    const events: CalendarEvent[] = dayOrder.map((day, index) => ({
+  const eventsForApi = useCallback((): CalendarEvent[] => {
+    return dayOrder.map((day, index) => ({
       id: 'event-' + index,
       day,
       eventType: eventsByDay[day],
     }));
+  }, [eventsByDay]);
+
+  const mergeRecommendationsIntoSets = useCallback(
+    (
+      nextRecommendations: DayRecommendation[],
+      sourceType: 'original' | 'regenerated',
+      append: boolean
+    ): DayRecommendationSet[] => {
+      const byDay = new Map<DayOfWeek, DayRecommendation>();
+      nextRecommendations.forEach((rec) => byDay.set(rec.day, rec));
+
+      return dayOrder
+        .filter((day) => byDay.has(day))
+        .map((day) => {
+          const recommendation = byDay.get(day)!;
+          const existing = recommendationSets.find((set) => set.day === day);
+          const existingVariants = append ? (existing?.variants ?? []) : [];
+          const previousSelected =
+            existing?.variants.find((v) => v.id === existing.selectedVariantId) ?? null;
+          const nextVariant = buildVariant(
+            recommendation,
+            existingVariants.length,
+            sourceType,
+            append ? previousSelected ?? undefined : undefined
+          );
+          const variants = existingVariants.concat(nextVariant);
+          return {
+            day,
+            variants: variants.map((variant, idx) => ({
+              ...variant,
+              label: createVariantLabel(idx),
+            })),
+            selectedVariantId: existing?.selectedVariantId ?? nextVariant.id,
+          };
+        });
+    },
+    [recommendationSets]
+  );
+
+  const emitSelectedRecommendations = useCallback((sets: DayRecommendationSet[]) => {
+    const selected = sets
+      .map((set) => set.variants.find((v) => v.id === set.selectedVariantId) ?? set.variants[0])
+      .filter(Boolean)
+      .map((variant) => variant!.recommendation)
+      .sort((a, b) => dayOrder.indexOf(a.day) - dayOrder.indexOf(b.day));
+    setRecommendations(selected);
+  }, []);
+
+  const buildPinConstraints = useCallback((sets: DayRecommendationSet[]): RecommendationPinConstraint[] => {
+    return sets
+      .map((set) => {
+        const selected = set.variants.find((v) => v.id === set.selectedVariantId) ?? set.variants[0];
+        if (!selected) return null;
+        const pins = selected.pinnedPieces;
+        if (!selected.pinWholeOutfit && !pins.top && !pins.bottom && !pins.dress) {
+          return null;
+        }
+        return {
+          day: set.day,
+          pinWholeOutfit: selected.pinWholeOutfit,
+          topId: selected.pinWholeOutfit || pins.top ? selected.recommendation.outfit.topId : undefined,
+          bottomId:
+            selected.pinWholeOutfit || pins.bottom ? selected.recommendation.outfit.bottomId : undefined,
+          dressId: selected.pinWholeOutfit || pins.dress ? selected.recommendation.outfit.dressId : undefined,
+        } satisfies RecommendationPinConstraint;
+      })
+      .filter((value): value is RecommendationPinConstraint => Boolean(value));
+  }, []);
+
+  const generateRecommendations = useCallback(async () => {
+    const events = eventsForApi();
     await saveWeekEvents(userId, events);
     const response = await getWeeklyRecommendations(userId, events, userGender);
-    setRecommendations(
-      response.recommendations.sort(
-        (a, b) => dayOrder.indexOf(a.day) - dayOrder.indexOf(b.day)
-      )
+    const sorted = response.recommendations.sort(
+      (a, b) => dayOrder.indexOf(a.day) - dayOrder.indexOf(b.day)
     );
-  }, [userId, eventsByDay, userGender]);
+    const sets = mergeRecommendationsIntoSets(sorted, 'original', false);
+    setRecommendationSets(sets);
+    emitSelectedRecommendations(sets);
+  }, [userId, eventsForApi, userGender, mergeRecommendationsIntoSets, emitSelectedRecommendations]);
+
+  const regenerateRecommendationsWithPins = useCallback(async () => {
+    const events = eventsForApi();
+    await saveWeekEvents(userId, events);
+    const pinConstraints = buildPinConstraints(recommendationSets);
+    const response = await getWeeklyRecommendations(userId, events, userGender, pinConstraints);
+    const sorted = response.recommendations.sort(
+      (a, b) => dayOrder.indexOf(a.day) - dayOrder.indexOf(b.day)
+    );
+    const sets = mergeRecommendationsIntoSets(sorted, 'regenerated', true);
+    setRecommendationSets(sets);
+    emitSelectedRecommendations(sets);
+  }, [
+    userId,
+    eventsForApi,
+    userGender,
+    recommendationSets,
+    buildPinConstraints,
+    mergeRecommendationsIntoSets,
+    emitSelectedRecommendations,
+  ]);
+
+  const setSelectedRecommendationVariant = useCallback(
+    async (day: DayOfWeek, variantId: string): Promise<void> => {
+      let analyticsPayload: RecommendationChoicePayload | null = null;
+      setRecommendationSets((current) => {
+        const next = current.map((set) => {
+          if (set.day !== day) return set;
+          const selected = set.variants.find((variant) => variant.id === variantId);
+          if (selected) {
+            analyticsPayload = {
+              userId,
+              day,
+              chosenVariantId: selected.id,
+              sourceType: selected.sourceType,
+              pinWholeOutfit: selected.pinWholeOutfit,
+              pinnedPieceKeys: Object.entries(selected.pinnedPieces)
+                .filter(([, pinned]) => pinned)
+                .map(([piece]) => piece),
+            };
+          }
+          return { ...set, selectedVariantId: variantId };
+        });
+        emitSelectedRecommendations(next);
+        return next;
+      });
+      if (analyticsPayload) {
+        await trackRecommendationChoice(analyticsPayload);
+      }
+    },
+    [userId, emitSelectedRecommendations]
+  );
+
+  const setPinWholeOutfit = useCallback((day: DayOfWeek, variantId: string, pinned: boolean) => {
+    setRecommendationSets((current) =>
+      current.map((set) => {
+        if (set.day !== day) return set;
+        return {
+          ...set,
+          variants: set.variants.map((variant) => {
+            if (variant.id !== variantId) return variant;
+            return {
+              ...variant,
+              pinWholeOutfit: pinned,
+              pinnedPieces: pinned
+                ? { top: true, bottom: true, dress: true }
+                : variant.pinnedPieces,
+            };
+          }),
+        };
+      })
+    );
+  }, []);
+
+  const setPinPiece = useCallback(
+    (
+      day: DayOfWeek,
+      variantId: string,
+      piece: keyof RecommendationPinnedPieces,
+      pinned: boolean
+    ) => {
+      setRecommendationSets((current) =>
+        current.map((set) => {
+          if (set.day !== day) return set;
+          return {
+            ...set,
+            variants: set.variants.map((variant) => {
+              if (variant.id !== variantId) return variant;
+              return {
+                ...variant,
+                pinnedPieces: {
+                  ...variant.pinnedPieces,
+                  [piece]: pinned,
+                },
+              };
+            }),
+          };
+        })
+      );
+    },
+    []
+  );
 
   const addGarmentToWardrobe = useCallback(async (payload: {
     name: string;
@@ -403,6 +618,7 @@ export function AppStateProvider({
       eventsByDay,
       summariesByDay,
       recommendations,
+      recommendationSets,
       isCalendarConnected,
       isLoadingWardrobe,
       wardrobeError,
@@ -413,6 +629,10 @@ export function AppStateProvider({
       useDemoWeek,
       syncCalendarEvents,
       generateRecommendations,
+      regenerateRecommendationsWithPins,
+      setSelectedRecommendationVariant,
+      setPinWholeOutfit,
+      setPinPiece,
       addGarmentToWardrobe,
       addGarmentViaVision,
       previewVisionItems,
@@ -428,6 +648,7 @@ export function AppStateProvider({
       eventsByDay,
       summariesByDay,
       recommendations,
+      recommendationSets,
       isCalendarConnected,
       isLoadingWardrobe,
       wardrobeError,
@@ -438,6 +659,10 @@ export function AppStateProvider({
       useDemoWeek,
       syncCalendarEvents,
       generateRecommendations,
+      regenerateRecommendationsWithPins,
+      setSelectedRecommendationVariant,
+      setPinWholeOutfit,
+      setPinPiece,
       addGarmentToWardrobe,
       addGarmentViaVision,
       previewVisionItems,

--- a/misfitai-mobile/src/WeeklyPlanScreen.tsx
+++ b/misfitai-mobile/src/WeeklyPlanScreen.tsx
@@ -86,6 +86,8 @@ export function WeeklyPlanScreen({
     setSelectedRecommendationVariant,
     setPinWholeOutfit,
     setPinPiece,
+    userProfile,
+    userId,
   } = useAppState();
   const [regenerating, setRegenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/misfitai-mobile/src/WeeklyPlanScreen.tsx
+++ b/misfitai-mobile/src/WeeklyPlanScreen.tsx
@@ -122,14 +122,16 @@ export function WeeklyPlanScreen({
   }, [avatarImageUrl]);
 
   useEffect(() => {
-    if (recommendationSets.length === 0) {
-      return;
-    }
-    const selectedExists = recommendationSets.some((item) => item.day === selectedDay);
+    const sourceDays =
+      recommendationSets.length > 0
+        ? recommendationSets.map((item) => item.day)
+        : recommendations.map((item) => item.day);
+    if (sourceDays.length === 0) return;
+    const selectedExists = sourceDays.includes(selectedDay);
     if (!selectedExists) {
-      setSelectedDay(recommendationSets[0].day);
+      setSelectedDay(sourceDays[0]);
     }
-  }, [recommendationSets, selectedDay]);
+  }, [recommendationSets, recommendations, selectedDay]);
 
   const selectedRecommendationSet = useMemo(() => {
     if (recommendationSets.length === 0) {
@@ -149,7 +151,13 @@ export function WeeklyPlanScreen({
     );
   }, [selectedRecommendationSet]);
 
-  const selectedRecommendation = selectedVariant?.recommendation ?? null;
+  const selectedRecommendation = useMemo(() => {
+    if (selectedVariant?.recommendation) {
+      return selectedVariant.recommendation;
+    }
+    if (recommendations.length === 0) return null;
+    return recommendations.find((item) => item.day === selectedDay) || recommendations[0];
+  }, [selectedVariant, recommendations, selectedDay]);
 
   // Animate card whenever the day changes
   useEffect(() => {
@@ -387,7 +395,9 @@ export function WeeklyPlanScreen({
             <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.dayTabs}>
               {dayOrder.map((day) => {
                 const active = selectedDay === day;
-                const hasRecommendation = recommendationSets.some((item) => item.day === day);
+                const hasRecommendation =
+                  recommendationSets.some((item) => item.day === day) ||
+                  recommendations.some((item) => item.day === day);
                 return (
                   <Pressable
                     key={day}

--- a/misfitai-mobile/src/WeeklyPlanScreen.tsx
+++ b/misfitai-mobile/src/WeeklyPlanScreen.tsx
@@ -51,7 +51,16 @@ export function WeeklyPlanScreen({
   onNavigateToWardrobe?: () => void;
   onBackToCalendar?: () => void;
 }) {
-  const { garments, recommendations, toggleGarmentHidden } = useAppState();
+  const {
+    garments,
+    recommendations,
+    recommendationSets,
+    toggleGarmentHidden,
+    regenerateRecommendationsWithPins,
+    setSelectedRecommendationVariant,
+    setPinWholeOutfit,
+    setPinPiece,
+  } = useAppState();
   const [regenerating, setRegenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedDay, setSelectedDay] = useState<DayOfWeek>('monday');
@@ -60,23 +69,35 @@ export function WeeklyPlanScreen({
   const pieceAnimations = useRef([0, 1, 2, 3].map(() => new Animated.Value(0))).current;
 
   useEffect(() => {
-    if (recommendations.length === 0) {
+    if (recommendationSets.length === 0) {
       return;
     }
 
-    const selectedExists = recommendations.some((item) => item.day === selectedDay);
+    const selectedExists = recommendationSets.some((item) => item.day === selectedDay);
     if (!selectedExists) {
-      setSelectedDay(recommendations[0].day);
+      setSelectedDay(recommendationSets[0].day);
     }
-  }, [recommendations, selectedDay]);
+  }, [recommendationSets, selectedDay]);
 
-  const selectedRecommendation = useMemo(() => {
-    if (recommendations.length === 0) {
+  const selectedRecommendationSet = useMemo(() => {
+    if (recommendationSets.length === 0) {
       return null;
     }
+    return recommendationSets.find((item) => item.day === selectedDay) || recommendationSets[0];
+  }, [recommendationSets, selectedDay]);
 
-    return recommendations.find((item) => item.day === selectedDay) || recommendations[0];
-  }, [recommendations, selectedDay]);
+  const selectedVariant = useMemo(() => {
+    if (!selectedRecommendationSet) {
+      return null;
+    }
+    return (
+      selectedRecommendationSet.variants.find(
+        (item) => item.id === selectedRecommendationSet.selectedVariantId
+      ) || selectedRecommendationSet.variants[0]
+    );
+  }, [selectedRecommendationSet]);
+
+  const selectedRecommendation = selectedVariant?.recommendation ?? null;
 
   useEffect(() => {
     if (!selectedRecommendation) {
@@ -109,7 +130,11 @@ export function WeeklyPlanScreen({
     try {
       setRegenerating(true);
       setError(null);
-      await onRegenerateWeek();
+      if (recommendationSets.length === 0) {
+        await onRegenerateWeek();
+      } else {
+        await regenerateRecommendationsWithPins();
+      }
     } catch {
       setError('Failed to regenerate week.');
     } finally {
@@ -243,7 +268,7 @@ export function WeeklyPlanScreen({
             <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.dayTabs}>
               {dayOrder.map((day) => {
                 const active = selectedDay === day;
-                const hasRecommendation = recommendations.some((item) => item.day === day);
+                const hasRecommendation = recommendationSets.some((item) => item.day === day);
                 return (
                   <Pressable
                     key={day}
@@ -252,6 +277,32 @@ export function WeeklyPlanScreen({
                   >
                     <Text style={[styles.dayTabText, active && styles.dayTabTextActive]}>
                       {dayLabels[day].slice(0, 3)}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.variantTabs}
+            >
+              {(selectedRecommendationSet?.variants || []).map((variant) => {
+                const active = selectedVariant?.id === variant.id;
+                return (
+                  <Pressable
+                    key={variant.id}
+                    onPress={() => {
+                      setError(null);
+                      setSelectedRecommendationVariant(selectedRecommendationSet!.day, variant.id).catch(() => {
+                        setError('Could not save selected option.');
+                      });
+                    }}
+                    style={[styles.variantTab, active && styles.variantTabActive]}
+                  >
+                    <Text style={[styles.variantTabText, active && styles.variantTabTextActive]}>
+                      {variant.label}
                     </Text>
                   </Pressable>
                 );
@@ -274,7 +325,55 @@ export function WeeklyPlanScreen({
                 },
               ]}
             >
-              <Text style={styles.lookHeading}>Recommended outfit</Text>
+              <Text style={styles.lookHeading}>{selectedVariant?.label || 'Recommended outfit'}</Text>
+              <Text style={styles.lookMeta}>
+                {selectedVariant?.sourceType === 'original' ? 'First suggestion' : 'Regenerated suggestion'}
+              </Text>
+
+              {selectedVariant ? (
+                <View style={styles.pinRow}>
+                  <Pressable
+                    style={[styles.pinChip, selectedVariant.pinWholeOutfit && styles.pinChipActive]}
+                    onPress={() =>
+                      setPinWholeOutfit(
+                        selectedRecommendationSet!.day,
+                        selectedVariant.id,
+                        !selectedVariant.pinWholeOutfit
+                      )
+                    }
+                  >
+                    <Text style={[styles.pinChipText, selectedVariant.pinWholeOutfit && styles.pinChipTextActive]}>
+                      {selectedVariant.pinWholeOutfit ? 'Whole outfit pinned' : 'Pin whole outfit'}
+                    </Text>
+                  </Pressable>
+                  {(['top', 'bottom', 'dress'] as const).map((piece) => (
+                    <Pressable
+                      key={piece}
+                      style={[
+                        styles.pinChip,
+                        selectedVariant.pinnedPieces[piece] && styles.pinChipActive,
+                      ]}
+                      onPress={() =>
+                        setPinPiece(
+                          selectedRecommendationSet!.day,
+                          selectedVariant.id,
+                          piece,
+                          !selectedVariant.pinnedPieces[piece]
+                        )
+                      }
+                    >
+                      <Text
+                        style={[
+                          styles.pinChipText,
+                          selectedVariant.pinnedPieces[piece] && styles.pinChipTextActive,
+                        ]}
+                      >
+                        {selectedVariant.pinnedPieces[piece] ? `Pinned ${piece}` : `Pin ${piece}`}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+              ) : null}
               <Text style={styles.lookReason}>{selectedRecommendation.explanation}</Text>
 
               <View style={styles.collageGrid}>
@@ -416,6 +515,30 @@ const styles = StyleSheet.create({
     gap: 8,
     paddingRight: 8,
   },
+  variantTabs: {
+    gap: 8,
+    paddingRight: 8,
+  },
+  variantTab: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: palette.line,
+    backgroundColor: palette.panelStrong,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  variantTabActive: {
+    borderColor: palette.accent,
+    backgroundColor: palette.accentSoft,
+  },
+  variantTabText: {
+    color: palette.inkSoft,
+    fontSize: 12,
+    fontFamily: type.bodyMedium,
+  },
+  variantTabTextActive: {
+    color: palette.accent,
+  },
   dayTab: {
     borderRadius: radius.pill,
     borderWidth: 1,
@@ -452,6 +575,37 @@ const styles = StyleSheet.create({
     lineHeight: 31,
     color: palette.ink,
     fontFamily: type.display,
+  },
+  lookMeta: {
+    marginTop: -8,
+    color: palette.muted,
+    fontSize: 12,
+    fontFamily: type.bodyMedium,
+  },
+  pinRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  pinChip: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: palette.lineStrong,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    backgroundColor: palette.panelStrong,
+  },
+  pinChipActive: {
+    borderColor: palette.accent,
+    backgroundColor: palette.accentSoft,
+  },
+  pinChipText: {
+    color: palette.inkSoft,
+    fontSize: 11,
+    fontFamily: type.bodyMedium,
+  },
+  pinChipTextActive: {
+    color: palette.accent,
   },
   lookReason: {
     color: palette.muted,

--- a/misfitai-mobile/src/api.ts
+++ b/misfitai-mobile/src/api.ts
@@ -268,6 +268,23 @@ export interface WeekEventsRequest {
   }[];
 }
 
+export interface RecommendationPinConstraint {
+  day: DayOfWeek;
+  pinWholeOutfit?: boolean;
+  topId?: string | null;
+  bottomId?: string | null;
+  dressId?: string | null;
+}
+
+export interface RecommendationChoicePayload {
+  userId: string;
+  day: DayOfWeek;
+  chosenVariantId: string;
+  sourceType: 'original' | 'regenerated';
+  pinWholeOutfit: boolean;
+  pinnedPieceKeys: string[];
+}
+
 export class ApiError extends Error {
   status: number;
   body: string;
@@ -966,6 +983,7 @@ export async function getWeeklyRecommendations(
   userId: string,
   events: CalendarEvent[],
   userGender?: string | null,
+  pinConstraints?: RecommendationPinConstraint[],
 ): Promise<{ recommendations: DayRecommendation[] }> {
   if (USE_MOCK_API) {
     return mockGetWeeklyRecommendations(userId, events);
@@ -982,6 +1000,13 @@ export async function getWeeklyRecommendations(
         day: event.day,
         event_type: eventTypeForApi(event.eventType),
       })),
+      pin_constraints: (pinConstraints || []).map((constraint) => ({
+        day: constraint.day,
+        pin_whole_outfit: Boolean(constraint.pinWholeOutfit),
+        top_id: constraint.topId ?? undefined,
+        bottom_id: constraint.bottomId ?? undefined,
+        dress_id: constraint.dressId ?? undefined,
+      })),
     }),
   });
 
@@ -991,6 +1016,25 @@ export async function getWeeklyRecommendations(
   return {
     recommendations: recs.map(mapRecommendation),
   };
+}
+
+export async function trackRecommendationChoice(
+  payload: RecommendationChoicePayload
+): Promise<void> {
+  if (USE_MOCK_API) {
+    return;
+  }
+  await requestJson<unknown>('/analytics/recommendation-choice', {
+    method: 'POST',
+    body: JSON.stringify({
+      user_id: payload.userId,
+      day: payload.day,
+      chosen_variant_id: payload.chosenVariantId,
+      source_type: payload.sourceType,
+      pin_whole_outfit: payload.pinWholeOutfit,
+      pinned_piece_keys: payload.pinnedPieceKeys,
+    }),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/misfitai-mobile/src/types.ts
+++ b/misfitai-mobile/src/types.ts
@@ -82,6 +82,29 @@ export interface DayRecommendation {
   explanation: string;
 }
 
+export type RecommendationSourceType = 'original' | 'regenerated';
+
+export interface RecommendationPinnedPieces {
+  top: boolean;
+  bottom: boolean;
+  dress: boolean;
+}
+
+export interface RecommendationVariant {
+  id: string;
+  label: string;
+  sourceType: RecommendationSourceType;
+  recommendation: DayRecommendation;
+  pinWholeOutfit: boolean;
+  pinnedPieces: RecommendationPinnedPieces;
+}
+
+export interface DayRecommendationSet {
+  day: DayOfWeek;
+  variants: RecommendationVariant[];
+  selectedVariantId: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // User profile (style preferences, sizes, avatar)
 // ---------------------------------------------------------------------------

--- a/scripts/sql/analytics_recommendation_choice_events.sql
+++ b/scripts/sql/analytics_recommendation_choice_events.sql
@@ -1,0 +1,14 @@
+-- Tracks the outfit variant users selected (original vs regenerated).
+create table if not exists public.recommendation_choice_events (
+  id bigserial primary key,
+  user_id text not null,
+  day text not null,
+  chosen_variant_id text not null,
+  source_type text not null,
+  pin_whole_outfit boolean not null default false,
+  pinned_piece_keys jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists recommendation_choice_events_user_id_idx
+  on public.recommendation_choice_events (user_id);


### PR DESCRIPTION
- Implemented Issue #48 : regenerating outfits now preserves the original suggestion and adds labeled alternatives instead of replacing results. 
- Added pinning mechanics for whole outfits and individual pieces (top/bottom/dress), and wired regenerate requests to respect those pin constraints. 
- Updated weekly plan UI to support variant selection and side-by-side option flow while keeping existing design patterns. 
- Added selection tracking for recommendation choices in both frontend state and backend (POST /analytics/recommendation-choice), including pin metadata. 
- Extended backend models/router/engine for pin-aware recommendation generation and added SQL for recommendation-choice analytics storage. 
- Added/updated integration tests for pin constraints and recommendation-choice tracking. 
- Resolved frontend Jest failures by keeping backward-compatible rendering when only legacy recommendations are present.